### PR TITLE
chore(Dockerfile) Update image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16-bullseye-slim@sha256:b0a27877c45f2d31d54a6197bcca1bbd1e307a557b1f655c8fbe80170567ca3e
 WORKDIR /usr/src/app
 
 ARG GIT_SHA
@@ -11,5 +11,7 @@ ENV TZ=US/Central
 ENV GIT_SHA=${GIT_SHA}
 
 EXPOSE ${PORT}
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 CMD ["npm", "start"]


### PR DESCRIPTION
## Goal

This updates the `From` node image we are using to one with many less
vulnerabilities.

```
Base Image             Vulnerabilities  Severity
node:16.13.1-bullseye  171              6 critical, 11 high, 29 medium,
125 low

Recommendations for base image upgrade:

Alternative image types
Base Image                  Vulnerabilities  Severity
node:current-slim           37               1 critical, 2 high, 0
medium, 34 low
node:16.13.1-bullseye-slim  37               1 critical, 2 high, 0
medium, 34 low
node:17.0-buster-slim       62               2 critical, 11 high, 5
medium, 44 low
node:17.3.0-buster          370              3 critical, 37 high, 67
medium, 263 low
```


What changed? What is the business/product goal?

- Updating the from image. I noticed this looking through the Amazon Inspector from the Log4J fallout. I picked one of the smaller images to see how updating this would go.
