### PR TITLE
feat(pagination): validating pagination inputs to receive first alone, last alone or the combination of {after, first} and {before,last}.

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -79,4 +79,8 @@ export default {
   },
   parserDomain: process.env.PARSER_DOMAIN || 'https://parse-sir.local',
   parserVersion: process.env.PARSER_VERSION || 'v3beta',
+  pagination: {
+    defaultPageSize: 30,
+    maxPageSize: 100
+  }
 };

--- a/src/dataService/queryServices/savedItemsService.ts
+++ b/src/dataService/queryServices/savedItemsService.ts
@@ -177,7 +177,7 @@ export class SavedItemDataService {
     // TODO: Implement filter and sort
     // TODO: Add sensible defaults and a limit if none is provided (naked before/after)
     if (pagination == null) {
-      pagination = { first: 30 };
+      pagination = { first: config.pagination.defaultPageSize };
     }
     const sortOrder = sort?.sortOrder ?? 'DESC';
     const sortColumn = this.sortMap[sort?.sortBy] ?? '_createdAt';

--- a/src/dataService/queryServices/tagDataService.ts
+++ b/src/dataService/queryServices/tagDataService.ts
@@ -1,9 +1,10 @@
 import { Knex } from 'knex';
 import { IContext } from '../../server/context';
 import { knexPaginator as paginate } from '@pocket/apollo-cursor-pagination';
-import { defaultPage, PaginationInput, Tag, TagEdge } from '../../types';
+import { PaginationInput, Tag, TagEdge } from '../../types';
 import { TagObjectMapper } from '../tagObjectMapper';
 import { cleanAndValidateTag } from '../utils';
+import config from '../../config';
 
 export class TagDataService {
   private readDb: Knex;
@@ -90,7 +91,7 @@ export class TagDataService {
     userId: string,
     pagination?: PaginationInput
   ): Promise<any> {
-    pagination = pagination ?? { first: defaultPage };
+    pagination = pagination ?? { first: config.pagination.defaultPageSize };
     const query = this.getItemsByTagsAndUser();
     const result = await paginate(
       query,

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -11,6 +11,9 @@ import {
   SavedItemDataService,
   TagDataService,
 } from '../dataService/queryServices';
+import {
+  validatePagination
+} from './utils'
 import { IContext } from '../server/context';
 
 /**
@@ -42,6 +45,7 @@ export function savedItems(
   },
   context: IContext
 ): Promise<SavedItemConnection> {
+  validatePagination(args.pagination);
   return new SavedItemDataService(context).getSavedItems(
     args.filter,
     args.sort,
@@ -62,6 +66,7 @@ export async function tags(
   },
   context: IContext
 ): Promise<TagConnection> {
+  validatePagination(args.pagination);
   return await new TagDataService(context).getTagsByUser(
     parent.id,
     args.pagination

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -11,9 +11,7 @@ import {
   SavedItemDataService,
   TagDataService,
 } from '../dataService/queryServices';
-import {
-  validatePagination
-} from './utils'
+import { validatePagination } from './utils';
 import { IContext } from '../server/context';
 
 /**

--- a/src/resolvers/utils.spec.ts
+++ b/src/resolvers/utils.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { Tag } from '../types';
-import { getSavedItemMapFromTags } from './utils';
+import { getSavedItemMapFromTags, validatePagination } from './utils';
+import { validate } from 'graphql';
 
 describe('getSavedItemMapFromTags', () => {
   it('should return a savedItem map from a list of tags', () => {
@@ -11,5 +12,41 @@ describe('getSavedItemMapFromTags', () => {
     const expected = { '1': [tagA, tagB], '2': [tagA], '3': [tagB] };
     const actual = getSavedItemMapFromTags(input);
     expect(actual).to.deep.equal(expected);
+  });
+});
+
+describe('pagination validation', () => {
+  it('should throw error if first and last are set', () => {
+    const pagination = { first: 100, last: 20 };
+    expect(() => validatePagination(pagination)).throw(
+      'Please set either {after and first} or {before and last}'
+    );
+  });
+
+  it('should throw error if before and after are set', () => {
+    const pagination = { before: 'b_cursor', after: 'a_cursor' };
+    expect(() => validatePagination(pagination)).throw(
+      'Please set either {after and first} or {before and last}'
+    );
+  });
+
+  it('should throw error when cursor is negative number', () => {
+    const before =  Buffer.from('-1').toString('base64');
+    const pagination = { before: before, last: 10 };
+    expect(() => validatePagination(pagination)).throw(
+      'invalid before cursor'
+    );
+  });
+
+  it('set default pagination size if no size is given', () => {
+    const before =  Buffer.from('10').toString('base64');
+    const actual = validatePagination({before: before});
+    expect(actual).to.deep.equal({before: before, last: 30});
+  });
+
+  it('set first to default pagination size if input is negative', () => {
+    const after =  Buffer.from('10').toString('base64');
+    const actual = validatePagination({after: after, first: -20 });
+    expect(actual).to.deep.equal({after: after, first: 30});
   });
 });

--- a/src/resolvers/utils.spec.ts
+++ b/src/resolvers/utils.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
-import { Tag } from '../types';
+import { defaultPage, maxPageSize, Tag } from '../types';
 import { getSavedItemMapFromTags, validatePagination } from './utils';
-import { validate } from 'graphql';
 
 describe('getSavedItemMapFromTags', () => {
   it('should return a savedItem map from a list of tags', () => {
@@ -30,23 +29,54 @@ describe('pagination validation', () => {
     );
   });
 
-  it('should throw error when cursor is negative number', () => {
-    const before =  Buffer.from('-1').toString('base64');
-    const pagination = { before: before, last: 10 };
+  it('should throw error if before and first are set', () => {
+    const pagination = { before: 'b_cursor', first: 20 };
     expect(() => validatePagination(pagination)).throw(
-      'invalid before cursor'
+      'Please set either {after and first} or {before and last}'
     );
   });
 
-  it('set default pagination size if no size is given', () => {
-    const before =  Buffer.from('10').toString('base64');
-    const actual = validatePagination({before: before});
-    expect(actual).to.deep.equal({before: before, last: 30});
+  it('should throw error when cursor is negative number', () => {
+    const before = Buffer.from('-1').toString('base64');
+    const pagination = { before: before, last: 10 };
+    expect(() => validatePagination(pagination)).throw('invalid before cursor');
   });
 
-  it('set first to default pagination size if input is negative', () => {
-    const after =  Buffer.from('10').toString('base64');
-    const actual = validatePagination({after: after, first: -20 });
-    expect(actual).to.deep.equal({after: after, first: 30});
+  it('should set last to default pagination size if before is set', () => {
+    const before = Buffer.from('10').toString('base64');
+    const actual = validatePagination({ before: before });
+    expect(actual).to.deep.equal({ before: before, last: defaultPage });
+  });
+
+  it('should set last to default pagination size if its negative', () => {
+    const before = Buffer.from('10').toString('base64');
+    const actual = validatePagination({ before: before, last: -20 });
+    expect(actual).to.deep.equal({ before: before, last: defaultPage });
+  });
+
+  it('should set first to default pagination size if its negative', () => {
+    const after = Buffer.from('10').toString('base64');
+    const actual = validatePagination({ after: after, first: -20 });
+    expect(actual).to.deep.equal({ after: after, first: defaultPage });
+  });
+
+  it('should set last to default pagination size if its negative', () => {
+    const actual = validatePagination({ last: -20 });
+    expect(actual).to.deep.equal({ last: defaultPage });
+  });
+
+  it('should set first if pagination is null', () => {
+    const actual = validatePagination(null);
+    expect(actual).to.deep.equal({ first: defaultPage });
+  });
+
+  it('should set first to maxPageSize if its greater than maxPageSize', () => {
+    const actual = validatePagination({ first: 200 });
+    expect(actual).to.deep.equal({ first: maxPageSize });
+  });
+
+  it('should set last to maxPageSize if its greater than maxPageSize', () => {
+    const actual = validatePagination({ last: 200 });
+    expect(actual).to.deep.equal({ last: maxPageSize });
   });
 });

--- a/src/resolvers/utils.spec.ts
+++ b/src/resolvers/utils.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
-import { defaultPage, maxPageSize, Tag } from '../types';
+import { Tag } from '../types';
 import { getSavedItemMapFromTags, validatePagination } from './utils';
+import config from '../config';
 
 describe('getSavedItemMapFromTags', () => {
   it('should return a savedItem map from a list of tags', () => {
@@ -15,6 +16,9 @@ describe('getSavedItemMapFromTags', () => {
 });
 
 describe('pagination validation', () => {
+  const defaultPageSize = config.pagination.defaultPageSize;
+  const maxPageSize = config.pagination.maxPageSize;
+
   it('should throw error if first and last are set', () => {
     const pagination = { first: 100, last: 20 };
     expect(() => validatePagination(pagination)).throw(
@@ -39,35 +43,35 @@ describe('pagination validation', () => {
   it('should throw error when cursor is negative number', () => {
     const before = Buffer.from('-1').toString('base64');
     const pagination = { before: before, last: 10 };
-    expect(() => validatePagination(pagination)).throw('invalid before cursor');
+    expect(() => validatePagination(pagination)).throw('Invalid before cursor');
   });
 
   it('should set last to default pagination size if before is set', () => {
     const before = Buffer.from('10').toString('base64');
     const actual = validatePagination({ before: before });
-    expect(actual).to.deep.equal({ before: before, last: defaultPage });
+    expect(actual).to.deep.equal({ before: before, last: defaultPageSize });
   });
 
   it('should set last to default pagination size if its negative', () => {
     const before = Buffer.from('10').toString('base64');
     const actual = validatePagination({ before: before, last: -20 });
-    expect(actual).to.deep.equal({ before: before, last: defaultPage });
+    expect(actual).to.deep.equal({ before: before, last: defaultPageSize });
   });
 
   it('should set first to default pagination size if its negative', () => {
     const after = Buffer.from('10').toString('base64');
     const actual = validatePagination({ after: after, first: -20 });
-    expect(actual).to.deep.equal({ after: after, first: defaultPage });
+    expect(actual).to.deep.equal({ after: after, first: defaultPageSize });
   });
 
   it('should set last to default pagination size if its negative', () => {
     const actual = validatePagination({ last: -20 });
-    expect(actual).to.deep.equal({ last: defaultPage });
+    expect(actual).to.deep.equal({ last: defaultPageSize });
   });
 
   it('should set first if pagination is null', () => {
     const actual = validatePagination(null);
-    expect(actual).to.deep.equal({ first: defaultPage });
+    expect(actual).to.deep.equal({ first: defaultPageSize });
   });
 
   it('should set first to maxPageSize if its greater than maxPageSize', () => {

--- a/src/resolvers/utils.ts
+++ b/src/resolvers/utils.ts
@@ -2,7 +2,7 @@
  * Returns a savedItemMap from the list of tags.
  * @param tags list of tags from which savedItem keys are generated.
  */
-import { defaultPage, PaginationInput } from '../types';
+import { defaultPage, maxPageSize, PaginationInput } from '../types';
 
 export function getSavedItemMapFromTags(tags) {
   const savedItemMap = {};
@@ -40,7 +40,7 @@ export function validatePagination(pagination: PaginationInput) {
       throw new Error('invalid before cursor');
     }
 
-    if(!pagination.last) {
+    if (!pagination.last) {
       pagination.last = defaultPage;
     }
   }
@@ -51,7 +51,7 @@ export function validatePagination(pagination: PaginationInput) {
       throw new Error('invalid after cursor');
     }
 
-    if(!pagination.first) {
+    if (!pagination.first) {
       pagination.first = defaultPage;
     }
   }
@@ -62,6 +62,14 @@ export function validatePagination(pagination: PaginationInput) {
 
   if (pagination.last <= 0) {
     pagination.last = defaultPage;
+  }
+
+  if (pagination.first > maxPageSize) {
+    pagination.first = maxPageSize;
+  }
+
+  if (pagination.last > maxPageSize) {
+    pagination.last = maxPageSize;
   }
 
   return pagination;

--- a/src/resolvers/utils.ts
+++ b/src/resolvers/utils.ts
@@ -2,7 +2,9 @@
  * Returns a savedItemMap from the list of tags.
  * @param tags list of tags from which savedItem keys are generated.
  */
-import { defaultPage, maxPageSize, PaginationInput } from '../types';
+import { PaginationInput } from '../types';
+import { UserInputError } from 'apollo-server-errors';
+import config from '../config';
 
 export function getSavedItemMapFromTags(tags) {
   const savedItemMap = {};
@@ -19,8 +21,11 @@ export function getSavedItemMapFromTags(tags) {
 }
 
 export function validatePagination(pagination: PaginationInput) {
+  const defaultPageSize = config.pagination.defaultPageSize;
+  const maxPageSize = config.pagination.maxPageSize;
+
   if (pagination == null) {
-    return { first: defaultPage };
+    return { first: defaultPageSize };
   }
 
   if (
@@ -29,7 +34,7 @@ export function validatePagination(pagination: PaginationInput) {
     (pagination.last && pagination.after) ||
     (pagination.first && pagination.last)
   ) {
-    throw new Error('Please set either {after and first} or {before and last}');
+    throw new UserInputError('Please set either {after and first} or {before and last}');
   }
 
   if (pagination.before) {
@@ -37,31 +42,31 @@ export function validatePagination(pagination: PaginationInput) {
       Buffer.from(pagination.before, 'base64').toString()
     );
     if (before < 0) {
-      throw new Error('invalid before cursor');
+      throw new UserInputError('Invalid before cursor');
     }
 
     if (!pagination.last) {
-      pagination.last = defaultPage;
+      pagination.last = defaultPageSize;
     }
   }
 
   if (pagination.after) {
     const after = parseInt(Buffer.from(pagination.after, 'base64').toString());
     if (after < 0) {
-      throw new Error('invalid after cursor');
+      throw new UserInputError('Invalid after cursor');
     }
 
     if (!pagination.first) {
-      pagination.first = defaultPage;
+      pagination.first = defaultPageSize;
     }
   }
 
   if (pagination.first <= 0) {
-    pagination.first = defaultPage;
+    pagination.first = defaultPageSize;
   }
 
   if (pagination.last <= 0) {
-    pagination.last = defaultPage;
+    pagination.last = defaultPageSize;
   }
 
   if (pagination.first > maxPageSize) {

--- a/src/resolvers/utils.ts
+++ b/src/resolvers/utils.ts
@@ -2,6 +2,7 @@
  * Returns a savedItemMap from the list of tags.
  * @param tags list of tags from which savedItem keys are generated.
  */
+import { defaultPage, PaginationInput } from '../types';
 
 export function getSavedItemMapFromTags(tags) {
   const savedItemMap = {};
@@ -15,4 +16,53 @@ export function getSavedItemMapFromTags(tags) {
     });
   });
   return savedItemMap;
+}
+
+export function validatePagination(pagination: PaginationInput) {
+  if (pagination == null) {
+    return { first: defaultPage };
+  }
+
+  if (
+    (pagination.before && pagination.after) ||
+    (pagination.before && pagination.first) ||
+    (pagination.last && pagination.after) ||
+    (pagination.first && pagination.last)
+  ) {
+    throw new Error('Please set either {after and first} or {before and last}');
+  }
+
+  if (pagination.before) {
+    const before = parseInt(
+      Buffer.from(pagination.before, 'base64').toString()
+    );
+    if (before < 0) {
+      throw new Error('invalid before cursor');
+    }
+
+    if(!pagination.last) {
+      pagination.last = defaultPage;
+    }
+  }
+
+  if (pagination.after) {
+    const after = parseInt(Buffer.from(pagination.after, 'base64').toString());
+    if (after < 0) {
+      throw new Error('invalid after cursor');
+    }
+
+    if(!pagination.first) {
+      pagination.first = defaultPage;
+    }
+  }
+
+  if (pagination.first <= 0) {
+    pagination.first = defaultPage;
+  }
+
+  if (pagination.last <= 0) {
+    pagination.last = defaultPage;
+  }
+
+  return pagination;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,9 +123,6 @@ export type SavedItemUpsertInput = {
   timestamp?: number;
 };
 
-export const defaultPage = 30;
-export const maxPageSize = 100;
-
 /**
  * Keeping the arbitrary numbers consistent with this enum
  */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,6 +124,7 @@ export type SavedItemUpsertInput = {
 };
 
 export const defaultPage = 30;
+export const maxPageSize = 100;
 
 /**
  * Keeping the arbitrary numbers consistent with this enum


### PR DESCRIPTION
## Goal 
validate pagination for combination
- first
- first/after
- last
- last/after


## feedback on
- restricted to the max first/last limit to 100. this way, we can restrict large db read at once..

Jira ticket:
https://getpocket.atlassian.net/browse/INFRA-2

