### PR TITLE
fix: reuse dataloaders within same request context

### DIFF
--- a/src/server/context.spec.ts
+++ b/src/server/context.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ContextManager } from './context';
+import { ContextManager, IContext } from './context';
 import { Knex } from 'knex';
 import DataLoader from 'dataloader';
 import { SavedItemDataService } from '../dataService/queryServices';
@@ -19,18 +19,18 @@ describe('context', () => {
       givenUrl: 'dont-care.com',
     },
   };
-  let batchQueryFnSpy;
+  let batchUrlFnSpy;
+  let batchIdFnSpy;
+  let context: IContext;
 
   beforeEach(() => {
-    batchQueryFnSpy =
+    batchUrlFnSpy =
       SavedItemDataService.prototype.batchGetSavedItemsByGivenUrls = jest
         .fn()
         .mockResolvedValue([savedItem]);
-  });
-  afterEach(() => jest.clearAllMocks());
-
-  it('creates a data loader for saved items on initialization', async () => {
-    const context = new ContextManager({
+    batchIdFnSpy = SavedItemDataService.prototype.batchGetSavedItemsByGivenIds =
+      jest.fn().mockResolvedValue([savedItem]);
+    context = new ContextManager({
       request: {
         headers: { userid: '1', apiid: '0' },
       },
@@ -40,27 +40,21 @@ describe('context', () => {
       },
       eventEmitter: null,
     });
+  });
 
+  afterEach(() => jest.clearAllMocks());
+
+  it('creates a data loader for saved items on initialization', async () => {
     const savedItems = await context.dataLoaders.savedItemsByUrl.load(
       'dont-care.com'
     );
 
     expect(context.dataLoaders.savedItemsByUrl).to.be.instanceof(DataLoader);
-    expect(batchQueryFnSpy.mock.calls[0][0]).to.deep.equal(['dont-care.com']);
+    expect(context.dataLoaders.savedItemsByUrl).to.be.instanceof(DataLoader);
+    expect(batchUrlFnSpy.mock.calls[0][0]).to.deep.equal(['dont-care.com']);
     expect(savedItems).to.deep.equal(savedItem);
   });
   it('Uses the same dataloader for every load request', async () => {
-    const context = new ContextManager({
-      request: {
-        headers: { userid: '1', apiid: '0' },
-      },
-      db: {
-        readClient: jest.fn() as unknown as Knex,
-        writeClient: jest.fn() as unknown as Knex,
-      },
-      eventEmitter: null,
-    });
-
     // Referencing the loader 2x should return the same object
     const loader = context.dataLoaders.savedItemsByUrl;
     const loaderAgain = context.dataLoaders.savedItemsByUrl;
@@ -74,6 +68,28 @@ describe('context', () => {
     );
     await loaderAgain.load('dont-care.com');
     // Second load should have used the cache, so only one call to batch fn
-    expect(batchQueryFnSpy.mock.calls.length).to.equal(1);
+    expect(batchUrlFnSpy.mock.calls.length).to.equal(1);
+  });
+  it('savedItemById dataloader should fill cache of savedItemByUrl dataloader', async () => {
+    await context.dataLoaders.savedItemsById.load('1');
+    const loadedItem = await context.dataLoaders.savedItemsByUrl.load(
+      'dont-care.com'
+    );
+    expect(
+      Array.from((context.dataLoaders.savedItemsById as any)._cacheMap.keys())
+    ).to.contain('1');
+    expect(batchIdFnSpy.mock.calls.length).to.equal(1);
+    expect(batchUrlFnSpy.mock.calls.length).to.equal(0);
+    expect(loadedItem).to.deep.equal(savedItem);
+  });
+  it('savedItemByUrl dataloader should fill cache of savedItemById dataloader', async () => {
+    await context.dataLoaders.savedItemsByUrl.load('dont-care.com');
+    const loadedItem = await context.dataLoaders.savedItemsById.load('1');
+    expect(
+      Array.from((context.dataLoaders.savedItemsById as any)._cacheMap.keys())
+    ).to.contain('1');
+    expect(batchUrlFnSpy.mock.calls.length).to.equal(1);
+    expect(batchIdFnSpy.mock.calls.length).to.equal(0);
+    expect(loadedItem).to.deep.equal(savedItem);
   });
 });

--- a/src/server/context.spec.ts
+++ b/src/server/context.spec.ts
@@ -19,38 +19,17 @@ describe('context', () => {
       givenUrl: 'dont-care.com',
     },
   };
+  let batchQueryFnSpy;
+
+  beforeEach(() => {
+    batchQueryFnSpy =
+      SavedItemDataService.prototype.batchGetSavedItemsByGivenUrls = jest
+        .fn()
+        .mockResolvedValue([savedItem]);
+  });
   afterEach(() => jest.clearAllMocks());
 
   it('creates a data loader for saved items on initialization', async () => {
-    const batchQueryFnSpy =
-      (SavedItemDataService.prototype.batchGetSavedItemsByGivenIds = jest
-        .fn()
-        .mockResolvedValue([savedItem]));
-
-    const context = new ContextManager({
-      request: {
-        headers: { userid: '1', apiid: '0' },
-      },
-      db: {
-        readClient: jest.fn() as unknown as Knex,
-        writeClient: jest.fn() as unknown as Knex,
-      },
-      eventEmitter: null,
-    });
-
-    const savedItems = await context.dataLoaders.savedItemsById.load('1');
-
-    expect(context.dataLoaders.savedItemsById).to.be.instanceof(DataLoader);
-    expect(batchQueryFnSpy.mock.calls[0][0]).to.deep.equal(['1']);
-    expect(savedItems).to.deep.equal(savedItem);
-  });
-
-  it('creates a data loader for saved items on initialization', async () => {
-    const batchQueryFnSpy =
-      (SavedItemDataService.prototype.batchGetSavedItemsByGivenUrls = jest
-        .fn()
-        .mockResolvedValue([savedItem]));
-
     const context = new ContextManager({
       request: {
         headers: { userid: '1', apiid: '0' },
@@ -69,5 +48,32 @@ describe('context', () => {
     expect(context.dataLoaders.savedItemsByUrl).to.be.instanceof(DataLoader);
     expect(batchQueryFnSpy.mock.calls[0][0]).to.deep.equal(['dont-care.com']);
     expect(savedItems).to.deep.equal(savedItem);
+  });
+  it('Uses the same dataloader for every load request', async () => {
+    const context = new ContextManager({
+      request: {
+        headers: { userid: '1', apiid: '0' },
+      },
+      db: {
+        readClient: jest.fn() as unknown as Knex,
+        writeClient: jest.fn() as unknown as Knex,
+      },
+      eventEmitter: null,
+    });
+
+    // Referencing the loader 2x should return the same object
+    const loader = context.dataLoaders.savedItems;
+    const loaderAgain = context.dataLoaders.savedItems;
+    await loader.load('dont-care.com');
+    // At this point both loaders should have filled cache since referencing same object
+    expect(Array.from((loader as any)._cacheMap.keys())).to.contain(
+      'dont-care.com'
+    );
+    expect(Array.from((loaderAgain as any)._cacheMap.keys())).to.contain(
+      'dont-care.com'
+    );
+    await loaderAgain.load('dont-care.com');
+    // Second load should have used the cache, so only one call to batch fn
+    expect(batchQueryFnSpy.mock.calls.length).to.equal(1);
   });
 });

--- a/src/server/context.spec.ts
+++ b/src/server/context.spec.ts
@@ -62,8 +62,8 @@ describe('context', () => {
     });
 
     // Referencing the loader 2x should return the same object
-    const loader = context.dataLoaders.savedItems;
-    const loaderAgain = context.dataLoaders.savedItems;
+    const loader = context.dataLoaders.savedItemsByUrl;
+    const loaderAgain = context.dataLoaders.savedItemsByUrl;
     await loader.load('dont-care.com');
     // At this point both loaders should have filled cache since referencing same object
     expect(Array.from((loader as any)._cacheMap.keys())).to.contain(

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -9,10 +9,7 @@ import { Knex } from 'knex';
 import { SavedItem } from '../types';
 import { TagDataService } from '../dataService/queryServices';
 import DataLoader from 'dataloader';
-import {
-  createSavedItemsDataLoaderById,
-  createSavedItemsDataLoaderUrls,
-} from '../dataLoader/savedItemsDataLoader';
+import { createSavedItemDataLoaders } from '../dataLoader/savedItemsDataLoader';
 
 export interface IContext {
   userId: string;
@@ -24,8 +21,8 @@ export interface IContext {
   };
   eventEmitter: ItemsEventEmitter;
   dataLoaders: {
-    savedItemsById: DataLoader<any, any>;
-    savedItemsByUrl: DataLoader<any, any>;
+    savedItemsById: DataLoader<string, SavedItem>;
+    savedItemsByUrl: DataLoader<string, SavedItem>;
   };
 
   emitItemEvent(
@@ -45,10 +42,7 @@ export class ContextManager implements IContext {
       eventEmitter: ItemsEventEmitter;
     }
   ) {
-    this.dataLoaders = {
-      savedItemsById: createSavedItemsDataLoaderById(this),
-      savedItemsByUrl: createSavedItemsDataLoaderUrls(this),
-    };
+    this.dataLoaders = createSavedItemDataLoaders(this);
   }
 
   get headers(): { [key: string]: any } {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -36,13 +36,20 @@ export interface IContext {
 }
 
 export class ContextManager implements IContext {
+  public readonly dataLoaders: IContext['dataLoaders'];
+
   constructor(
     private config: {
       request: any;
       db: { readClient: Knex; writeClient: Knex };
       eventEmitter: ItemsEventEmitter;
     }
-  ) {}
+  ) {
+    this.dataLoaders = {
+      savedItemsById: createSavedItemsDataLoaderById(this),
+      savedItemsByUrl: createSavedItemsDataLoaderUrls(this),
+    };
+  }
 
   get headers(): { [key: string]: any } {
     return this.config.request.headers;
@@ -68,13 +75,6 @@ export class ContextManager implements IContext {
 
   get db(): IContext['db'] {
     return this.config.db;
-  }
-
-  get dataLoaders(): IContext['dataLoaders'] {
-    return {
-      savedItemsById: createSavedItemsDataLoaderById(this),
-      savedItemsByUrl: createSavedItemsDataLoaderUrls(this),
-    };
   }
 
   get eventEmitter(): ItemsEventEmitter {


### PR DESCRIPTION
## Goal

We should make a dataloader for each new request (each time the context is created). Subsequent calls to the dataloader on the same context object should return the same dataloader object. This fixes a bug where a new dataloader was created every time the property was accessed (resulting in no actual batch/cache).

Also adds a small optimization to fill both SavedItem loader caches when one is accessed (loading by ID/Url fills both loader caches)

## Implementation decisions
* Fill dataloader cache of alternate key when one is accessed (i.e. loading a SavedItem by ID fills the cache for SavedItem by url)

## References
[INFRA-258]

[INFRA-258]: https://getpocket.atlassian.net/browse/INFRA-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ