### PR TITLE
fix(SavedItemsFilter): only use active highlights for isHighlighted

### DIFF
--- a/src/dataService/queryServices/savedItemsService.ts
+++ b/src/dataService/queryServices/savedItemsService.ts
@@ -326,6 +326,7 @@ export class SavedItemDataService {
     const highlightSubquery = this.readDb('user_annotations')
       .select('user_id as hl_user_id', 'item_id as hl_item_id')
       .where('user_id', this.userId)
+      .andWhere('status', 1)
       .groupBy('hl_user_id', 'hl_item_id')
       .as('highlights');
 

--- a/src/test/functional/queryServices.test/savedItems-filters.integration.ts
+++ b/src/test/functional/queryServices.test/savedItems-filters.integration.ts
@@ -149,11 +149,19 @@ describe('getSavedItems filter', () => {
         user_id: 1,
         item_id: 1,
         annotation_id: 1,
+        status: 1,
       },
       {
         user_id: 1,
         item_id: 1,
         annotation_id: 2,
+        status: 1,
+      },
+      {
+        user_id: 1,
+        item_id: 2,
+        annotation_id: 3,
+        status: 0, // deleted highlight
       },
     ]);
     await db.raw('TRUNCATE TABLE readitla_b.items_extended');
@@ -319,7 +327,7 @@ describe('getSavedItems filter', () => {
     ).to.equal(false);
   });
 
-  it('should return highlighted items', async () => {
+  it('should return highlighted items with active (non-deleted) highlights only', async () => {
     const variables = {
       id: '1',
       filter: { isHighlighted: true },
@@ -335,7 +343,7 @@ describe('getSavedItems filter', () => {
     );
   });
 
-  it('should return non-highlighted items', async () => {
+  it('should return non-highlighted items (or items with only deleted highlights)', async () => {
     const variables = {
       id: '1',
       filter: { isHighlighted: false },


### PR DESCRIPTION
## Goal
Only use non-deleted highlights (status=1) for `isHighlighted` filter

## References

Jira ticket:
* https://getpocket.atlassian.net/browse/INFRA-310
