### PR TITLE
bugfix(savedItems): do not throw error if filter returns no result

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "eslint-config-prettier": "^8.4.0",
         "eslint-plugin-prettier": "^4.0.0",
         "faker": "^5.5.3",
-        "jest": "^27.5.1",
+        "jest": "27.5.1",
         "nock": "13.2.4",
         "nodemon": "^2.0.15",
         "prettier": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-prettier": "^4.0.0",
     "faker": "^5.5.3",
-    "jest": "^27.5.1",
+    "jest": "27.5.1",
     "nock": "13.2.4",
     "nodemon": "^2.0.15",
     "prettier": "^2.5.1",

--- a/src/dataService/listPaginationService.ts
+++ b/src/dataService/listPaginationService.ts
@@ -620,8 +620,10 @@ export class ListPaginationService {
         cursor: this.encodeCursor(node.id, node[sortColumn]),
       };
     });
-    pageInfo['startCursor'] = edges[0].cursor;
-    pageInfo['endCursor'] = edges[edges.length - 1].cursor;
+    if (edges.length) {
+      pageInfo['startCursor'] = edges[0].cursor;
+      pageInfo['endCursor'] = edges[edges.length - 1].cursor;
+    }
     return {
       edges,
       pageInfo,
@@ -632,7 +634,7 @@ export class ListPaginationService {
     pagedResult: ListEntity[],
     pagination: PaginationInput
   ) {
-    const pageInfo = {};
+    const pageInfo = { startCursor: null, endCursor: null };
     if (pagination.first) {
       pageInfo['hasNextPage'] = pagedResult.length > pagination.first;
       if (pagination.after) {

--- a/src/test/functional/queryServices.test/savedItems-filters.integration.ts
+++ b/src/test/functional/queryServices.test/savedItems-filters.integration.ts
@@ -42,6 +42,13 @@ describe('getSavedItems filter', () => {
       _entities(representations: { id: $id, __typename: "User" }) {
         ... on User {
           savedItems(pagination: { first: 30 }, filter: $filter) {
+            totalCount
+            pageInfo {
+              startCursor
+              endCursor
+              hasNextPage
+              hasPreviousPage
+            }
             edges {
               node {
                 url
@@ -325,6 +332,31 @@ describe('getSavedItems filter', () => {
     expect(
       res.data?._entities[0].savedItems.edges[0].node.item.savedItem.isFavorite
     ).to.equal(false);
+  });
+
+  it('should not throw an error if no items match the filters', async () => {
+    const variables = {
+      id: '1',
+      filter: {
+        isHighlighted: true,
+        contentType: 'VIDEO',
+        isFavorite: false,
+        status: 'ARCHIVED',
+      },
+    };
+    const res = await server.executeOperation({
+      query: GET_SAVED_ITEMS,
+      variables,
+    });
+    expect(res.errors).to.be.undefined;
+    expect(res.data?._entities[0].savedItems.edges).to.deep.equal([]);
+    expect(res.data?._entities[0].savedItems.totalCount).to.equal(0);
+    expect(res.data?._entities[0].savedItems.pageInfo).to.deep.equal({
+      startCursor: null,
+      endCursor: null,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
   });
 
   it('should return highlighted items with active (non-deleted) highlights only', async () => {


### PR DESCRIPTION
## Goal
Quick bugfix for a bug I found where an error was thrown if the filter did not return any results (due to attempting to access a field on an undefined object).
- Add test to capture case
- Update to pass test