### PR TITLE
[Donot Merge] : branch to mock the bulk tag mutations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,13 @@ jobs:
             - run:
                 name: push service
                 command: rover subgraph publish pocket-client-api@current --schema ./schema.graphql --routing-url https://list-api.readitlater.com/ --name=list
+      - when:
+          condition:
+            equal: [ dev, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: push service
+                command: rover subgraph publish pocket-client-api@development --schema ./schema.graphql --routing-url https://list-api.getpocket.dev/ --name=list
   build:
     docker:
       - image: circleci/node:16@sha256:1803e9ed7deec9456ad2609124b7333d40b2eec0cf34998ae766cbf90c9a3625

--- a/schema.graphql
+++ b/schema.graphql
@@ -362,19 +362,7 @@ input SavedItemTagUpdateInput {
   """
   tagIds: [ID!]!
 }
-"""
-Input field for creating a Tag
-"""
-input TagCreateInput {
-  """
-  The user provided tag string
-  """
-  name: String!
-  """
-  ID of the SavedItem to associate with this Tag
-  """
-  savedItemId: ID!
-}
+
 """
 Input field for updating a Tag
 """
@@ -503,6 +491,20 @@ extend type Item @key(fields: "givenUrl") {
 }
 
 """
+Input field for setting all Tag associations on a SavedItem.
+"""
+input SavedItemTagsInput {
+  """
+  The SavedItem ID to associate Tags to
+  """
+  savedItemId: ID!
+  """
+  The set of Tag names to associate to the SavedItem
+  """
+  name: [String!]!
+}
+
+"""
 Default Mutation Type
 """
 type Mutation {
@@ -537,12 +539,6 @@ type Mutation {
   """
   updateSavedItemUnFavorite(id: ID!): SavedItem!
 
-  """
-  Set the Tags that are associated with a SavedItem.
-  Will replace any existing Tag associations on the SavedItem.
-  To remove all Tags from a SavedItem, use `updateSavedItemRemoveTags`.
-  """
-  updateSavedItemTags(input: SavedItemTagUpdateInput!): SavedItem!
 
   """
   Removes all Tag associations from a SavedItem. Returns the
@@ -557,10 +553,35 @@ type Mutation {
   deleted SavedItem
   """
   deleteSavedItem(id: ID!): ID!
+
   """
-  Creates user tags that a user can use to classify SavedItems
+  Add tags to the savedItems
+  Inputs a list of SavedItemTagsInput(ie. savedItemId and the list of tagName)
+  Returns the list of `SavedItem` for which the tags were added
   """
-  createTags(input: [TagCreateInput!]!): [Tag!]!
+  createSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
+
+  """
+  Replaces the old tags associated with the savedItem to the new tag list
+  given in the entry
+  To remove all Tags from a SavedItem, use `updateSavedItemRemoveTags`.
+  Note: if there is a new tag name in the SavedItemTagUpdateInput, then the tag record will be created
+  Inputs a list of SavedItemTagsInput(ie. savedItemId and list of tag names)
+  Returns the SavedItem for which the tags have been modified.
+  """
+  replaceSavedItemTags(input: [SavedItemTagsInput!]): [SavedItem!]
+
+  """
+  Deletes the association between a Tag and a SavedItem
+  (removes a Tag from a SavedItem).
+  Note that if this operation results in a Tag having no associations
+  to a SavedItem, the Tag object will be deleted.
+  Returns the list of savedItems that has been affected by this mutation.
+  """
+  deleteSavedItemTags(
+    input: [DeleteSavedItemTagsInput!]!
+  ): [SavedItem]!
+
   """
   Updates a Tag (renames the tag), and returns the updated Tag.
   If a Tag with the updated name already exists in the database, will
@@ -573,13 +594,4 @@ type Mutation {
   (removes the Tag from all SavedItems). Returns ID of the deleted Tag.
   """
   deleteTag(id: ID!): ID!
-  """
-  Deletes the association between a Tag and a SavedItem
-  (removes a Tag from a SavedItem).
-  Note that if this operation results in a Tag having no associations
-  to a SavedItem, the Tag object will be deleted.
-  """
-  deleteSavedItemTags(
-    input: [DeleteSavedItemTagsInput!]!
-  ): [SavedItemTagAssociation]
 }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -66,7 +66,6 @@ export const resolvers = {
     updateSavedItemRemoveTags,
     createTags,
     updateTag,
-    deleteSavedItemTags,
     deleteTag,
   },
 };

--- a/src/server/apolloServer.ts
+++ b/src/server/apolloServer.ts
@@ -49,6 +49,7 @@ export function getContext(
 export function getServer(contextFactory: ContextFactory): ApolloServer {
   return new ApolloServer({
     schema: buildSubgraphSchema({ typeDefs, resolvers }),
+    mocks: true,
     plugins: [
       sentryPlugin,
       process.env.NODE_ENV === 'production'


### PR DESCRIPTION
branch to mock the bulk tag mutations for clients.

```
npm ci
docker-compose up
```

set header to 
```
{
  "userid" : "1"
}
```

to bulk create tags:
```
mutation{
   createSavedItemTags(input: [{ savedItemId: "1", name: ["colin"] },
    { savedItemId: "2", name: ["colin","wood"] }]) {
    id
    tags{
      name
    }
  }
}
```

to bulk update tags:
```
mutation{
   replaceSavedItemTags(input: [{ savedItemId: "1", name: ["colin"] },
    { savedItemId: "2", name: ["colin","wood"] }]) {
    id
    tags{
      name
    }
  }
}
```

to bulk delete tags,
```
mutation{
   deleteSavedItemTags(input: [{ savedItemId: "1", tagIds: ["tagId_1_some_guid"] },
    { savedItemId: "2", tagIds: ["tagId_2_some_guid","tagId_3_some_guid"] }]) {
    id
    tags{
      name
    }
  }
}
```

ticket: https://getpocket.atlassian.net/browse/INFRA-435