### PR TITLE
fix(tests): ensure sinon fake timer is only installed once in tests

### DIFF
--- a/.docker/mysql/schema/schema.sql
+++ b/.docker/mysql/schema/schema.sql
@@ -110,7 +110,7 @@ CREATE TABLE `items_scroll` (
   KEY `updated_at` (`updated_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-----Suggested Tags Tables
+-- Suggested Tags Tables
 CREATE TABLE `suggested_tags_user_grouping_tags` (
     user_id        int unsigned            not null,
     grouping_id    bigint unsigned         not null,

--- a/src/test/functional/mutationServices.test/savedItemsMutationService-delete.integration.ts
+++ b/src/test/functional/mutationServices.test/savedItemsMutationService-delete.integration.ts
@@ -87,13 +87,15 @@ describe('Delete/Undelete SavedItem: ', () => {
     clock.restore();
   });
 
-  beforeEach(async () => {
+  beforeAll(() => {
     // Mock Date.now() to get a consistent date for inserting data
     clock = sinon.useFakeTimers({
       now: updateDate,
-      shouldAdvanceTime: true,
+      shouldAdvanceTime: false,
     });
+  });
 
+  beforeEach(async () => {
     await db('list').truncate();
     await db('item_tags').truncate();
     await db('item_attribution').truncate();

--- a/src/test/functional/mutationServices.test/tagsMutationService-update.integration.ts
+++ b/src/test/functional/mutationServices.test/tagsMutationService-update.integration.ts
@@ -41,12 +41,6 @@ describe('updateTag Mutation: ', () => {
   });
 
   beforeEach(async () => {
-    // Mock Date.now() to get a consistent date for inserting data
-    clock = sinon.useFakeTimers({
-      now: updateDate,
-      shouldAdvanceTime: true,
-    });
-
     await db('item_tags').truncate();
     await db('item_tags').insert([
       {


### PR DESCRIPTION
## Goal
Ensure sinon fake timer is only installed once in tests.
`sinon.useFakeTimers` was being called more than once individual integration tests.

Root cause: sinon was bumped to version 13.x from 12.x

## References

Jira ticket: INFRA-440
