### PR TITLE
feat(mutations): set db connection to write for all mutations

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -595,11 +595,9 @@ type Mutation {
   """
   deleteSavedItemTags(
     input: [DeleteSavedItemTagsInput!]!
-  ): [SavedItemTagAssociation]
+  ): [SavedItem!]!
 
-  replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem]!
+  replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
 
-  createSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem]!
-
-  deleteSavedItemTags(input: [DeleteSavedItemTagsInput!]!): [SavedItem]!
+  createSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -490,20 +490,6 @@ type PendingItem @key(fields: "url") {
   status: PendingItemStatus
 }
 
-"""
-Input field for setting all Tag associations on a SavedItem.
-"""
-input SavedItemTagsInput {
-  """
-  The SavedItem ID to associate Tags to
-  """
-  savedItemId: ID!
-  """
-  The set of Tag names to associate to the SavedItem
-  """
-  tags: [String!]!
-}
-
 extend type Item @key(fields: "givenUrl") {
   "key field to identify the Item entity in the Parser service"
   givenUrl: Url! @external
@@ -595,9 +581,5 @@ type Mutation {
   """
   deleteSavedItemTags(
     input: [DeleteSavedItemTagsInput!]!
-  ): [SavedItem!]!
-
-  replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
-
-  createSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
+  ): [SavedItemTagAssociation]
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -490,6 +490,20 @@ type PendingItem @key(fields: "url") {
   status: PendingItemStatus
 }
 
+"""
+Input field for setting all Tag associations on a SavedItem.
+"""
+input SavedItemTagsInput {
+  """
+  The SavedItem ID to associate Tags to
+  """
+  savedItemId: ID!
+  """
+  The set of Tag names to associate to the SavedItem
+  """
+  tags: [String!]!
+}
+
 extend type Item @key(fields: "givenUrl") {
   "key field to identify the Item entity in the Parser service"
   givenUrl: Url! @external
@@ -582,4 +596,10 @@ type Mutation {
   deleteSavedItemTags(
     input: [DeleteSavedItemTagsInput!]!
   ): [SavedItemTagAssociation]
+
+  replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem]!
+
+  createSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem]!
+
+  deleteSavedItemTags(input: [DeleteSavedItemTagsInput!]!): [SavedItem]!
 }

--- a/src/dataService/listPaginationService.ts
+++ b/src/dataService/listPaginationService.ts
@@ -594,8 +594,8 @@ export class ListPaginationService {
     if (pagination == null) {
       pagination = { first: config.pagination.defaultPageSize };
     }
-    const { totalCount, pageResult } =
-      await this.context.db.readClient.transaction(async (trx) => {
+    const { totalCount, pageResult } = await this.context.dbClient.transaction(
+      async (trx) => {
         // Drop temp tables if exists.
         await this.dropTempTables(trx);
 
@@ -622,7 +622,8 @@ export class ListPaginationService {
           sort
         );
         return { totalCount, pageResult };
-      });
+      }
+    );
     const pageInfo: any = this.hydratePageInfo(pageResult, pagination);
     let nodes: SavedItemResult[];
     if (pagination.first) {

--- a/src/dataService/savedItemsService.ts
+++ b/src/dataService/savedItemsService.ts
@@ -36,13 +36,8 @@ export class SavedItemDataService {
   private readonly userId: string;
   private readonly apiId: string;
 
-  constructor(
-    context: IContext,
-    db: Knex = context.db.readClient
-    //note: for mutations, please pass the writeClient,
-    //otherwise there will be replication lags.
-  ) {
-    this.db = db;
+  constructor(context: IContext) {
+    this.db = context.dbClient;
     this.userId = context.userId;
     this.apiId = context.apiId;
   }
@@ -70,10 +65,6 @@ export class SavedItemDataService {
       return dbResult.map((row) => statusConvert(row));
     }
     return statusConvert(dbResult);
-  }
-
-  public static getWriteDbClient(context: IContext) {
-    return new SavedItemDataService(context, context.db.writeClient);
   }
 
   /**

--- a/src/dataService/tagDataService.ts
+++ b/src/dataService/tagDataService.ts
@@ -36,12 +36,11 @@ export class TagDataService {
 
   constructor(
     context: IContext,
-    savedItemDataService: SavedItemDataService,
-    db: Knex = context.db.readClient
+    savedItemDataService: SavedItemDataService
     //note: for mutations, please pass the writeClient,
     //otherwise there will be replication lags.
   ) {
-    this.db = db;
+    this.db = context.dbClient;
     this.userId = context.userId;
     this.apiId = context.apiId;
     this.savedItemService = savedItemDataService;
@@ -429,16 +428,5 @@ export class TagDataService {
     return this.db('item_tags')
       .where({ user_id: this.userId, tag: tagName })
       .del();
-  }
-
-  public static getWriteDbClient(
-    context: IContext,
-    savedItemService: SavedItemDataService
-  ) {
-    return new TagDataService(
-      context,
-      savedItemService,
-      context.db.writeClient
-    );
   }
 }

--- a/src/dataService/usersMetaService.ts
+++ b/src/dataService/usersMetaService.ts
@@ -15,8 +15,8 @@ export class UsersMetaService {
 
   constructor(context: IContext) {
     this.userId = context.userId;
-    this.knex = context.db.writeClient;
-    this.db = context.db.writeClient(UsersMetaService.tableName);
+    this.knex = context.dbClient;
+    this.db = context.dbClient(UsersMetaService.tableName);
   }
 
   /**

--- a/src/resolvers/index.spec.ts
+++ b/src/resolvers/index.spec.ts
@@ -1,15 +1,18 @@
 import { IContext } from '../server/context';
 import { executeMutation } from './index';
-import { writeClient } from '../database/client';
+import { readClient, writeClient } from '../database/client';
 
 describe('executeMutation spec test', () => {
+  afterAll(async () => {
+    await readClient().destroy();
+    await writeClient().destroy();
+  });
+
   it('should change client writeDbClient and calls the mutation function ', async () => {
     const testContext = {
-      db: {
-        client: null,
-        writeClient: writeClient(),
-      },
+      dbClient: readClient(),
     } as IContext;
+
     async function testMutation(
       parent,
       args,
@@ -20,7 +23,7 @@ describe('executeMutation spec test', () => {
 
     const anonymousFunction = executeMutation<any, string>(testMutation);
     const res = await anonymousFunction({}, { hello: 'world' }, testContext);
-    expect(testContext.db.client).toEqual(testContext.db.writeClient);
+    expect(testContext.dbClient).toEqual(writeClient());
     expect(res).toEqual('world');
   });
 });

--- a/src/resolvers/index.spec.ts
+++ b/src/resolvers/index.spec.ts
@@ -1,0 +1,26 @@
+import { IContext } from '../server/context';
+import { executeMutation } from './index';
+import { writeClient } from '../database/client';
+
+describe('executeMutation spec test', () => {
+  it('should change client writeDbClient and calls the mutation function ', async () => {
+    const testContext = {
+      db: {
+        client: null,
+        writeClient: writeClient(),
+      },
+    } as IContext;
+    async function testMutation(
+      parent,
+      args,
+      context: IContext
+    ): Promise<string> {
+      return args.hello;
+    }
+
+    const anonymousFunction = executeMutation<any, string>(testMutation);
+    const res = await anonymousFunction({}, { hello: 'world' }, testContext);
+    expect(testContext.db.client).toEqual(testContext.db.writeClient);
+    expect(res).toEqual('world');
+  });
+});

--- a/src/resolvers/item.ts
+++ b/src/resolvers/item.ts
@@ -1,6 +1,6 @@
 import { Item, SavedItem } from '../types';
 import { IContext } from '../server/context';
-import { SavedItemDataService } from '../dataService/savedItemsService';
+import { SavedItemDataService } from '../dataService';
 
 /**
  * Resolve saved item on the Item entity

--- a/src/server/apolloServer.ts
+++ b/src/server/apolloServer.ts
@@ -5,7 +5,7 @@ import { resolvers } from '../resolvers';
 import { errorHandler } from '@pocket-tools/apollo-utils';
 import { ItemsEventEmitter } from '../businessEvents';
 import { ContextManager } from './context';
-import { readClient, writeClient } from '../database/client';
+import { readClient } from '../database/client';
 import { Request } from 'express';
 import {
   ApolloServerPluginLandingPageGraphQLPlayground,
@@ -32,10 +32,7 @@ export function getContext(
 ): ContextManager {
   return new ContextManager({
     request: req,
-    db: {
-      readClient: readClient(),
-      writeClient: writeClient(),
-    },
+    dbClient: readClient(),
     eventEmitter: emitter,
   });
 }
@@ -56,7 +53,7 @@ export function getServer(contextFactory: ContextFactory): ApolloServer {
         : ApolloServerPluginLandingPageGraphQLPlayground(),
     ],
     formatError: errorHandler,
-    introspection: process.env.NODE_ENV === 'production' ? false : true,
+    introspection: process.env.NODE_ENV !== 'production',
     context: ({ req }) => contextFactory(req),
   });
 }

--- a/src/server/context.spec.ts
+++ b/src/server/context.spec.ts
@@ -34,10 +34,7 @@ describe('context', () => {
       request: {
         headers: { userid: '1', apiid: '0' },
       },
-      db: {
-        readClient: jest.fn() as unknown as Knex,
-        writeClient: jest.fn() as unknown as Knex,
-      },
+      dbClient: jest.fn() as unknown as Knex,
       eventEmitter: null,
     });
   });

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -16,11 +16,7 @@ export interface IContext {
   headers: IncomingHttpHeaders;
   apiId: string;
   userIsPremium: boolean;
-  db: {
-    client?: Knex;
-    readClient: Knex;
-    writeClient: Knex;
-  };
+  dbClient: Knex;
   eventEmitter: ItemsEventEmitter;
   dataLoaders: {
     savedItemsById: DataLoader<string, SavedItem>;
@@ -36,15 +32,17 @@ export interface IContext {
 
 export class ContextManager implements IContext {
   public readonly dataLoaders: IContext['dataLoaders'];
+  public dbClient: Knex;
 
   constructor(
     private config: {
       request: any;
-      db: { readClient: Knex; writeClient: Knex };
+      dbClient: Knex;
       eventEmitter: ItemsEventEmitter;
     }
   ) {
     this.dataLoaders = createSavedItemDataLoaders(this);
+    this.dbClient = config.dbClient;
   }
 
   get headers(): { [key: string]: any } {
@@ -73,10 +71,6 @@ export class ContextManager implements IContext {
     const apiId = this.headers.apiid || '0';
 
     return apiId instanceof Array ? apiId[0] : apiId;
-  }
-
-  get db(): IContext['db'] {
-    return this.config.db;
   }
 
   get eventEmitter(): ItemsEventEmitter {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -17,6 +17,7 @@ export interface IContext {
   apiId: string;
   userIsPremium: boolean;
   db: {
+    client?: Knex;
     readClient: Knex;
     writeClient: Knex;
   };

--- a/src/test/functional/mutationServices.test/savedItemsMutationService-delete.integration.ts
+++ b/src/test/functional/mutationServices.test/savedItemsMutationService-delete.integration.ts
@@ -1,4 +1,4 @@
-import { readClient, writeClient } from '../../../database/client';
+import { writeClient } from '../../../database/client';
 import { gql } from 'apollo-server-express';
 import chai, { expect } from 'chai';
 import chaiDateTime from 'chai-datetime';
@@ -72,17 +72,15 @@ async function setUpSavedItem(db: Knex, date: Date) {
 describe('Delete/Undelete SavedItem: ', () => {
   //using write client as mutation will use write client to read as well.
   const db = writeClient();
-  const readDb = readClient();
   const eventEmitter = new ItemsEventEmitter();
   const userId = '1';
-  const server = getServer(userId, readDb, db, eventEmitter);
+  const server = getServer(userId, db, eventEmitter);
 
   const date = new Date('2020-10-03 10:20:30');
   const updateDate = new Date(2021, 1, 1, 0, 0); // mock date for insert
   let clock;
 
   afterAll(async () => {
-    await readClient().destroy();
     await writeClient().destroy();
     clock.restore();
   });

--- a/src/test/functional/mutationServices.test/savedItemsMutationService-updates.integration.ts
+++ b/src/test/functional/mutationServices.test/savedItemsMutationService-updates.integration.ts
@@ -1,4 +1,4 @@
-import { readClient, writeClient } from '../../../database/client';
+import { writeClient } from '../../../database/client';
 import { gql } from 'apollo-server-express';
 import chai, { expect } from 'chai';
 import chaiDateTime from 'chai-datetime';
@@ -13,16 +13,14 @@ chai.use(chaiDateTime);
 describe('Update Mutation for SavedItem: ', () => {
   //using write client as mutation will use write client to read as well.
   const db = writeClient();
-  const readDb = readClient();
   const eventEmitter = new ItemsEventEmitter();
-  const server = getServer('1', readDb, db, eventEmitter);
+  const server = getServer('1', db, eventEmitter);
   const date = new Date('2020-10-03 10:20:30'); // Consistent date for seeding
   const date1 = new Date('2020-10-03 10:30:30'); // Consistent date for seeding
   const updateDate = new Date(2021, 1, 1, 0, 0); // mock date for insert
   let clock;
 
   afterAll(async () => {
-    await readDb.destroy();
     await db.destroy();
     clock.restore();
   });

--- a/src/test/functional/mutationServices.test/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/functional/mutationServices.test/savedItemsMutationService-upsert.integration.ts
@@ -1,4 +1,4 @@
-import { readClient, writeClient } from '../../../database/client';
+import { writeClient } from '../../../database/client';
 import { gql } from 'apollo-server-express';
 import chai, { expect } from 'chai';
 import chaiDateTime from 'chai-datetime';
@@ -29,7 +29,6 @@ function mockParserGetItemRequest(urlToParse: string, data: any) {
 
 describe('UpsertSavedItem Mutation', () => {
   const db = writeClient();
-  const readDb = readClient();
   const itemsEventEmitter = new ItemsEventEmitter();
   const sqsEventsToListen = Object.values(config.aws.sqs.publisherQueue.events);
   new SqsListener(
@@ -38,7 +37,7 @@ describe('UpsertSavedItem Mutation', () => {
     config.aws.sqs.publisherQueue.url,
     sqsEventsToListen
   );
-  const server = getServer('1', readDb, db, itemsEventEmitter);
+  const server = getServer('1', db, itemsEventEmitter);
   const date = new Date('2020-10-03 10:20:30'); // Consistent date for seeding
   const unixDate = getUnixTimestamp(date);
   const dateNow = new Date('2021-10-06 03:22:00');
@@ -52,8 +51,7 @@ describe('UpsertSavedItem Mutation', () => {
   });
 
   afterAll(async () => {
-    await readClient().destroy();
-    await writeClient().destroy();
+    await db.destroy();
     clock.restore();
     nock.cleanAll();
   });

--- a/src/test/functional/mutationServices.test/tagsMutationService-create.integration.ts
+++ b/src/test/functional/mutationServices.test/tagsMutationService-create.integration.ts
@@ -1,4 +1,4 @@
-import { readClient, writeClient } from '../../../database/client';
+import { writeClient } from '../../../database/client';
 import { gql } from 'apollo-server-express';
 import chai, { expect } from 'chai';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
@@ -15,9 +15,8 @@ chai.use(deepEqualInAnyOrder);
 describe('Mutation for Tag: ', () => {
   //using write client as mutation will use write client to read as well.
   const db = writeClient();
-  const readDb = readClient();
   const eventEmitter: ItemsEventEmitter = new ItemsEventEmitter();
-  const server = getServer('1', readDb, db, eventEmitter);
+  const server = getServer('1', db, eventEmitter);
   const createTagsMutation = gql`
     mutation createTags($input: [TagCreateInput!]!) {
       createTags(input: $input) {
@@ -41,8 +40,7 @@ describe('Mutation for Tag: ', () => {
   let clock;
 
   afterAll(async () => {
-    await readClient().destroy();
-    await writeClient().destroy();
+    await db.destroy();
     clock.restore();
   });
 

--- a/src/test/functional/mutationServices.test/tagsMutationService-delete.integration.ts
+++ b/src/test/functional/mutationServices.test/tagsMutationService-delete.integration.ts
@@ -1,4 +1,4 @@
-import { readClient, writeClient } from '../../../database/client';
+import { writeClient } from '../../../database/client';
 import { gql } from 'apollo-server-express';
 import chai, { expect } from 'chai';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
@@ -14,21 +14,19 @@ chai.use(chaiDateTime);
 
 describe('Mutation for Tag deletions: ', () => {
   const db = writeClient();
-  const readDb = readClient();
   const eventEmitter = new ItemsEventEmitter();
   const dbTagsQuery = db('item_tags').select('tag').pluck('tag');
   const listUpdatedQuery = db('list').select('time_updated');
   const listStateQuery = db('list').select();
   const tagStateQuery = db('item_tags').select();
   const metaStateQuery = db('users_meta').select();
-  const server = getServer('1', readDb, db, eventEmitter);
+  const server = getServer('1', db, eventEmitter);
 
   const date = new Date('2020-10-03 10:20:30'); // Consistent date for seeding
   const date1 = new Date('2020-10-03 10:30:30'); // Consistent date for seeding
 
   afterAll(async () => {
-    await readClient().destroy();
-    await writeClient().destroy();
+    await db.destroy();
   });
 
   afterEach(() => {

--- a/src/test/functional/mutationServices.test/tagsMutationService-update.integration.ts
+++ b/src/test/functional/mutationServices.test/tagsMutationService-update.integration.ts
@@ -1,4 +1,4 @@
-import { readClient, writeClient } from '../../../database/client';
+import { writeClient } from '../../../database/client';
 import { gql } from 'apollo-server-express';
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
@@ -16,9 +16,8 @@ chai.use(chaiDateTime);
 
 describe('updateTag Mutation: ', () => {
   const db = writeClient();
-  const readDb = readClient();
   const eventEmitter = new ItemsEventEmitter();
-  const server = getServer('1', readDb, db, eventEmitter);
+  const server = getServer('1', db, eventEmitter);
 
   const date = new Date('2020-10-03 10:20:30'); // Consistent date for seeding
   const date1 = new Date('2020-10-03 10:30:30'); // Consistent date for seeding
@@ -35,8 +34,7 @@ describe('updateTag Mutation: ', () => {
   });
 
   afterAll(async () => {
-    await readClient().destroy();
-    await writeClient().destroy();
+    await db.destroy();
     clock.restore();
   });
 

--- a/src/test/functional/mutationServices.test/tagsMutationService-updateSavedItemTags.integration.ts
+++ b/src/test/functional/mutationServices.test/tagsMutationService-updateSavedItemTags.integration.ts
@@ -1,4 +1,4 @@
-import { readClient, writeClient } from '../../../database/client';
+import { writeClient } from '../../../database/client';
 import { gql } from 'apollo-server-express';
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
@@ -16,11 +16,10 @@ chai.use(deepEqualInAnyOrder);
 chai.use(chaiDateTime);
 
 describe('tags mutation update: ', () => {
-  const db = readClient();
-  const readDb = readClient();
+  const db = writeClient();
   const eventEmitter: ItemsEventEmitter = new ItemsEventEmitter();
 
-  const server = getServer('1', readDb, db, eventEmitter);
+  const server = getServer('1', db, eventEmitter);
 
   const date = new Date('2020-10-03 10:20:30'); // Consistent date for seeding
   const unixDate = getUnixTimestamp(date);
@@ -39,7 +38,6 @@ describe('tags mutation update: ', () => {
 
   afterAll(async () => {
     await db.destroy();
-    await writeClient().destroy();
     clock.restore();
   });
 

--- a/src/test/functional/mutationServices.test/usersMetaService.integration.ts
+++ b/src/test/functional/mutationServices.test/usersMetaService.integration.ts
@@ -17,10 +17,7 @@ describe('UsersMetaService ', () => {
         apiid: '0',
       },
     },
-    db: {
-      readClient: readClient(),
-      writeClient: writeClient(),
-    },
+    dbClient: readClient(),
     eventEmitter: null,
   });
   const currentTime = new Date();

--- a/src/test/functional/queryServices.test/pagination-benchmarking.integration.ts
+++ b/src/test/functional/queryServices.test/pagination-benchmarking.integration.ts
@@ -32,7 +32,7 @@ const GET_SAVED_ITEMS = gql`
 `;
 describe.skip('temp table with new list pagination - benchmarking', () => {
   const db = readClient();
-  const server = getServer('1', readClient(), db, null);
+  const server = getServer('1', db, null);
   const variables = {
     id: '1',
     filter: { contentType: 'ARTICLE' },

--- a/src/test/functional/queryServices.test/savedItem.integration.ts
+++ b/src/test/functional/queryServices.test/savedItem.integration.ts
@@ -9,7 +9,7 @@ chai.use(chaiDateTime);
 
 describe('getSavedItemByItemId', () => {
   const db = readClient();
-  const server = getServer('1', readClient(), db, null);
+  const server = getServer('1', db, null);
 
   const date = new Date('2020-10-03 10:20:30'); // Consistent date for seeding
   const unixDate = getUnixTimestamp(date); // unix timestamp

--- a/src/test/functional/queryServices.test/savedItems-filters.integration.ts
+++ b/src/test/functional/queryServices.test/savedItems-filters.integration.ts
@@ -11,7 +11,7 @@ chai.use(deepEqualInAnyOrder);
 
 describe('getSavedItems filter', () => {
   const db = readClient();
-  const server = getServer('1', readClient(), db, null);
+  const server = getServer('1', db, null);
 
   // TODO: What date is the server running in? Web repo does central...
   // should this do UTC, this changes pagination cursors.

--- a/src/test/functional/queryServices.test/savedItems.integration.ts
+++ b/src/test/functional/queryServices.test/savedItems.integration.ts
@@ -10,7 +10,7 @@ chai.use(deepEqualInAnyOrder);
 
 describe('getSavedItems', () => {
   const db = readClient();
-  const server = getServer('1', readClient(), db, null);
+  const server = getServer('1', db, null);
 
   // TODO: What date is the server running in? Web repo does central...
   // should this do UTC, this changes pagination cursors.

--- a/src/test/functional/queryServices.test/tags-sadpath.integration.ts
+++ b/src/test/functional/queryServices.test/tags-sadpath.integration.ts
@@ -5,7 +5,7 @@ import { getServer } from '../testServerUtil';
 
 describe(' tags query tests - sad path validation', () => {
   const db = readClient();
-  const server = getServer('1', readClient(), db, null);
+  const server = getServer('1', db, null);
   const date = new Date('2020-10-03T10:20:30.000Z');
 
   afterAll(async () => {

--- a/src/test/functional/queryServices.test/tags.integration.ts
+++ b/src/test/functional/queryServices.test/tags.integration.ts
@@ -9,7 +9,7 @@ chai.use(chaiDateTime);
 
 describe('tags query tests - happy path', () => {
   const db = readClient();
-  const server = getServer('1', readClient(), db, null, { premium: 'true' });
+  const server = getServer('1', db, null, { premium: 'true' });
   const date = new Date('2020-10-03T10:20:30.000Z');
   const unixDate = getUnixTimestamp(date);
   const date1 = new Date('2021-10-03T10:20:30.000Z');

--- a/src/test/functional/testServerUtil.ts
+++ b/src/test/functional/testServerUtil.ts
@@ -13,8 +13,7 @@ import { errorHandler } from '@pocket-tools/apollo-utils';
 
 export function getServer(
   userId: string,
-  readClient: Knex,
-  writeClient: Knex,
+  dbClient: Knex,
   eventEmitter: ItemsEventEmitter,
   headers = {}
 ) {
@@ -34,10 +33,7 @@ export function getServer(
             ...headers,
           },
         },
-        db: {
-          readClient: readClient,
-          writeClient: writeClient,
-        },
+        dbClient: dbClient,
         eventEmitter: eventEmitter,
       });
     },

--- a/src/test/integration/savedItemsService.integration.ts
+++ b/src/test/integration/savedItemsService.integration.ts
@@ -51,10 +51,7 @@ describe('SavedItemsService', () => {
       request: {
         headers: { userid: '1', apiid: '0' },
       },
-      db: {
-        readClient: readClient(),
-        writeClient: writeClient(),
-      },
+      dbClient: readClient(),
       eventEmitter: null,
     });
 
@@ -71,10 +68,7 @@ describe('SavedItemsService', () => {
       request: {
         headers: { userid: '1', apiid: '0' },
       },
-      db: {
-        readClient: readClient(),
-        writeClient: writeClient(),
-      },
+      dbClient: readClient(),
       eventEmitter: null,
     });
 


### PR DESCRIPTION
## Goal

Use a consistent db connection (read / write) throughout the resolver chain for a given request.

For example, for the following mutation: 
```graphql
mutation CreateTags {
  createSavedItemTags({ savedItemId: 1, tags: ["this", "one"]}) {
    id
    tags {
      name  
    }
  }
}
```
`tags` is not resolved as part of the saved item, but through a separate resolver in the chain. In the original design, this would mean that the `tags` resolver will use a read db connection. The problem with using a read db connection after a mutation is that we lose strong consistency in the response to the client due to replication lag. 

The work in this PR ensures that for a mutation, every downstream resolver, uses the same connection i.e. the write db connection that was used to perform the mutation. This way we have a true representation of the state of a savedItem in the response to clients.

## I'd love feedback/perspectives on:
- Implementation

## Implementation Decisions
- Create a higher-order function that returns a resolver function for mutations:
  - Allows us to set the db connection in the context at the root of a mutation/query: ensures that every resolver in the chain uses the same connection

## References

Jira ticket: INFRA-433