### PR TITLE
feat(tags): update deleteSavedItemTags response

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -589,14 +589,13 @@ type Mutation {
   """
   deleteTag(id: ID!): ID!
   """
-  Deletes the association between a Tag and a SavedItem
-  (removes a Tag from a SavedItem).
+  Delete one or more tags from one or more SavedItems.
   Note that if this operation results in a Tag having no associations
   to a SavedItem, the Tag object will be deleted.
   """
   deleteSavedItemTags(
     input: [DeleteSavedItemTagsInput!]!
-  ): [SavedItemTagAssociation]
+  ): [SavedItem!]!
 
   """
   Replaces the old tags associated with the savedItem to the new tag list
@@ -607,4 +606,5 @@ type Mutation {
   Returns the SavedItem for which the tags have been modified.
   """
   replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
+  ): [SavedItem!]!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -606,5 +606,4 @@ type Mutation {
   Returns the SavedItem for which the tags have been modified.
   """
   replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
-  ): [SavedItem!]!
 }

--- a/src/resolvers/mutation.ts
+++ b/src/resolvers/mutation.ts
@@ -18,6 +18,7 @@ import { decodeBase64ToPlainText } from '../dataService/utils';
 import { getSavedItemMapFromTags } from './utils';
 import { NotFoundError } from '@pocket-tools/apollo-utils';
 import { ApolloError, UserInputError } from 'apollo-server-errors';
+import { String } from 'aws-sdk/clients/batch';
 
 /**
  * Create or re-add a saved item in a user's list.
@@ -301,28 +302,33 @@ export async function createTags(
 }
 
 /**
- * Mutation for untagging a saved item in a user's list
+ * Mutation for untagging a saved item in a user's list.
+ * Returns a list of SavedItem IDs to resolve
  */
 export async function deleteSavedItemTags(
   root,
   args: { input: DeleteSavedItemTagsInput[] },
   context: IContext
-): Promise<SavedItemTagAssociation[]> {
+): Promise<SavedItem[]> {
   try {
     const savedItemService = new SavedItemDataService(context);
     const tagDataService = new TagDataService(context, savedItemService);
-    const associations = await tagDataService.deleteSavedItemAssociations(
-      args.input
-    );
+    await tagDataService.deleteSavedItemAssociations(args.input);
 
+    const savedItemsToReturn = [];
     for (const association of args.input) {
+      const savedItem = savedItemService.getSavedItemById(
+        association.savedItemId
+      );
+
       context.emitItemEvent(
         EventType.REMOVE_TAGS,
-        savedItemService.getSavedItemById(association.savedItemId),
+        savedItem,
         association.tagIds.map((id) => decodeBase64ToPlainText(id))
       );
+      savedItemsToReturn.push(savedItem);
     }
-    return associations;
+    return savedItemsToReturn;
   } catch (e) {
     console.log(e);
     Sentry.captureException(e);

--- a/src/resolvers/mutation.ts
+++ b/src/resolvers/mutation.ts
@@ -5,7 +5,6 @@ import {
   TagUpdateInput,
   Tag,
   DeleteSavedItemTagsInput,
-  SavedItemTagAssociation,
   SavedItemTagUpdateInput,
   SavedItemTagsInput,
 } from '../types';
@@ -18,7 +17,6 @@ import { decodeBase64ToPlainText } from '../dataService/utils';
 import { getSavedItemMapFromTags } from './utils';
 import { NotFoundError } from '@pocket-tools/apollo-utils';
 import { ApolloError, UserInputError } from 'apollo-server-errors';
-import { String } from 'aws-sdk/clients/batch';
 
 /**
  * Create or re-add a saved item in a user's list.

--- a/src/test/functional/mutationServices.test/tagsMutationService-delete.integration.ts
+++ b/src/test/functional/mutationServices.test/tagsMutationService-delete.integration.ts
@@ -111,8 +111,9 @@ describe('Mutation for Tag deletions: ', () => {
         .where('item_id', 0)
         .first();
       expect(res.errors).to.be.undefined;
-      expect(res.data.deleteSavedItemTags.id).to.equal('0');
-      expect(res.data.deleteSavedItemTags.tags).to.deep.equalInAnyOrder([
+      expect(res.data.deleteSavedItemTags.length).to.equal(1);
+      expect(res.data.deleteSavedItemTags[0].id).to.equal('0');
+      expect(res.data.deleteSavedItemTags[0].tags).to.deep.equalInAnyOrder([
         { name: 'nandor' },
         { name: 'nadja' },
         { name: 'guillermo' },
@@ -170,9 +171,6 @@ describe('Mutation for Tag deletions: ', () => {
       const vampires = vampireNames.map((vampire) =>
         Buffer.from(vampire).toString('base64')
       );
-      const expectedTags = vampireNames.map((vampire) => ({
-        name: vampire,
-      }));
       const variables = {
         input: [{ savedItemId: '0', tagIds: vampires }],
       };
@@ -186,10 +184,10 @@ describe('Mutation for Tag deletions: ', () => {
         .where('item_id', 0)
         .first();
       expect(res.errors).to.be.undefined;
-      expect(res.data.deleteSavedItemTags.id).to.equal('0');
-      expect(res.data.deleteSavedItemTags.tags).to.deep.equalInAnyOrder(
-        expectedTags
-      );
+      expect(res.data.deleteSavedItemTags[0].id).to.equal('0');
+      expect(res.data.deleteSavedItemTags[0].tags).to.deep.equal([
+        { name: 'guillermo' },
+      ]);
       expect(dbTags.length).to.equal(1);
       expect(dbTags[0]).to.equal('guillermo');
       expect(listItem.time_updated).to.be.closeToTime(now, 5);
@@ -201,7 +199,6 @@ describe('Mutation for Tag deletions: ', () => {
       const newVampires = newVampireNames.map((vampire) =>
         Buffer.from(vampire).toString('base64')
       );
-      const oldVampireNames = ['deacon', 'viago', 'vladislav'];
       const oldVampires = ['deacon', 'viago', 'vladislav'].map((vampire) =>
         Buffer.from(vampire).toString('base64')
       );
@@ -225,12 +222,24 @@ describe('Mutation for Tag deletions: ', () => {
         .orWhere('item_id', 1)
         .pluck('time_updated');
       expect(res.errors).to.be.undefined;
-      const data = res.data.deleteSavedItemTags;
-      expect(data.id).to.deep.equalInAnyOrder(['0', '1']);
-      expect(data.id[data.id.indexOf('0')].tags).to.deep.equal({
-        name: 'guillermo',
-      });
-      expect(data.id[data.id.indexOf('0').tags]).to.be.null;
+      expect(res.data.deleteSavedItemTags.length).to.equal(2);
+      const expectedSavedItems = [
+        {
+          id: '0',
+          tags: [
+            {
+              name: 'guillermo',
+            },
+          ],
+        },
+        {
+          id: '1',
+          tags: [],
+        },
+      ];
+      expect(res.data.deleteSavedItemTags).to.deep.equalInAnyOrder(
+        expectedSavedItems
+      );
       updates.forEach((update) => {
         expect(update).to.be.closeToTime(now, 5);
       });


### PR DESCRIPTION
## Goal
update `deleteSavedItemTags` to return a `SavedItem` array instead of `SavedItemTagAssociation` (per https://github.com/Pocket/spec/blob/main/source/client-api/list/schema.graphql)

## I'd love feedback/perspectives on:
- 

## Implementation Decisions
- small spec update to not allow nulls in the response at all

## References

Jira ticket:
* https://getpocket.atlassian.net/browse/INFRA-438
