### PR TITLE
feat: limit argument array size for mutations

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,6 +13,7 @@ export default {
   app: {
     environment: process.env.NODE_ENV || 'development',
     depthLimit: 8,
+    bulkSizeLimit: 30,
   },
   events: {
     source: 'list-api', // TODO - ok to change from 'backend-php'?


### PR DESCRIPTION
## Goal
Limit argument size for mutations

## I'd love feedback/perspectives on:
- Is this the way to go? or risk of too generic (false positive)?
- We could instead do a per-mutation resolver, or pass in some kind of decorator-style argument/function currying/callback

## Implementation Decisions
- very naive array size checker in args


