### PR TITLE
fix(SQS): only premium users get Perm Lib

### DIFF
--- a/src/businessEvents/itemsEventEmitter.spec.ts
+++ b/src/businessEvents/itemsEventEmitter.spec.ts
@@ -27,7 +27,7 @@ describe('ItemsEventEmitter', () => {
 
   const payload: BasicItemEventPayloadWithContext = {
     savedItem: Promise.resolve(testSavedItem),
-    user: { id: '1' },
+    user: { id: '1', isPremium: false },
     apiUser: { apiId: '2' },
   };
 

--- a/src/businessEvents/sqs/transformers/index.ts
+++ b/src/businessEvents/sqs/transformers/index.ts
@@ -44,6 +44,8 @@ export async function publisherDataSqsTransformer(data: ItemEventPayload) {
  * @param data
  */
 export async function permLibSqsTransformer(data: ItemEventPayload) {
+  if (!data.user.isPremium) return null;
+
   const savedItem = await data.savedItem;
   return {
     userId: parseInt(data.user.id),

--- a/src/businessEvents/types.ts
+++ b/src/businessEvents/types.ts
@@ -30,6 +30,7 @@ export type BasicItemEventPayloadContext = {
     email?: string;
     guid?: number;
     hashedGuid?: string;
+    isPremium: boolean;
   };
   apiUser: {
     apiId: string;

--- a/src/businessEvents/unifiedEventKinesisHandler.spec.ts
+++ b/src/businessEvents/unifiedEventKinesisHandler.spec.ts
@@ -30,7 +30,7 @@ describe('UnifiedEventHandler', () => {
     const eventStub = {
       source: config.events.source,
       version: config.events.version,
-      user: { id: '1' },
+      user: { id: '1', isPremium: false },
       apiUser: { apiId: '1' },
       eventType: EventType.ADD_ITEM,
       data: { abc: '123' },
@@ -77,7 +77,7 @@ describe('UnifiedEventHandler', () => {
     const eventStub = {
       source: config.events.source,
       version: config.events.version,
-      user: { id: '1' },
+      user: { id: '1', isPremium: false },
       tagsUpdated: ['tagA', 'tagB'],
       apiUser: { apiId: '1' },
       eventType: EventType.ADD_TAGS,
@@ -107,7 +107,7 @@ describe('UnifiedEventHandler', () => {
     const eventStub = {
       source: config.events.source,
       version: config.events.version,
-      user: { id: '1' },
+      user: { id: '1', isPremium: false },
       apiUser: { apiId: '1' },
       eventType: EventType.ADD_ITEM,
       tagsUpdated: ['tagA', 'tagB'],

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -128,6 +128,7 @@ export class ContextManager implements IContext {
         email: this.headers.email,
         guid: parseInt(this.headers.guid),
         hashedGuid: this.headers.encodedguid,
+        isPremium: this.userIsPremium,
       },
       apiUser: {
         apiId: this.apiId,


### PR DESCRIPTION
## Goal
Only send message to the permanent library queue if user is premium

## References

Jira ticket: INFRA-574
