### PR TITLE
fix: keep promises in memory and send to sqs at once

### DIFF
--- a/src/server/routes/queueDelete.ts
+++ b/src/server/routes/queueDelete.ts
@@ -7,7 +7,6 @@ import config from '../../config';
 import { sqs } from '../../aws/sqs';
 import {
   SendMessageBatchCommand,
-  SendMessageBatchCommandOutput,
   SendMessageBatchRequestEntry,
 } from '@aws-sdk/client-sqs';
 import { nanoid } from 'nanoid';
@@ -86,7 +85,7 @@ export async function enqueueSavedItemIds(
   const { userId, email, status } = data;
   const limit = config.queueDelete.queryLimit;
   let offset = 0;
-  const sqsSends: Promise<SendMessageBatchCommandOutput>[] = [];
+  const sqsCommands: SendMessageBatchCommand[] = [];
   let sqsEntries: SendMessageBatchRequestEntry[] = [];
 
   const loopCondition = true;
@@ -109,7 +108,7 @@ export async function enqueueSavedItemIds(
       );
 
       if (sqsEntries.length === config.aws.sqs.batchSize) {
-        sqsSends.push(sqsSendBatch(sqsEntries));
+        sqsCommands.push(buildSqsCommand(sqsEntries));
         sqsEntries = []; // reset
       }
 
@@ -121,11 +120,22 @@ export async function enqueueSavedItemIds(
 
   // If there's any remaining, send to SQS
   if (sqsEntries.length) {
-    sqsSends.push(sqsSendBatch(sqsEntries));
+    sqsCommands.push(buildSqsCommand(sqsEntries));
   }
 
   try {
-    await Promise.all(sqsSends);
+    await Promise.allSettled(
+      sqsCommands.map((command) => {
+        return sqs.send(command).catch((err) => {
+          const message = `QueueDelete: Error - Failed to enqueue saved items for userId: ${userId} (command=\n${JSON.stringify(
+            command
+          )})`;
+          Sentry.addBreadcrumb({ message });
+          Sentry.captureException(err);
+          console.log(message);
+        });
+      })
+    );
   } catch (e) {
     const message = `QueueDelete: Error - Failed to enqueue saved items for userId: ${userId} (requestId='${requestId}')`;
     Sentry.addBreadcrumb({ message });
@@ -135,18 +145,18 @@ export async function enqueueSavedItemIds(
 }
 
 /**
- * Send messages in a batch to SQS
+ * Build command for sendign messages to the delete queue,
+ * for purging user data after account deletion.
  * @param entries
  */
-async function sqsSendBatch(
+function buildSqsCommand(
   entries: SendMessageBatchRequestEntry[]
-): Promise<SendMessageBatchCommandOutput> {
+): SendMessageBatchCommand {
   const command = new SendMessageBatchCommand({
     Entries: entries,
     QueueUrl: config.aws.sqs.listDeleteQueue.url,
   });
-
-  return sqs.send(command);
+  return command;
 }
 
 /**


### PR DESCRIPTION
This avoids issues with inconsistent offset pagination, which can occur if rows are being deleted as promises are resolved asynchronously.

Uses the same pattern as https://github.com/Pocket/account-data-deleter/pull/40/