### PR TITLE
fix(bug): return time_read as archivedAt

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -93,7 +93,7 @@ export default {
   parserVersion: process.env.PARSER_VERSION || 'v3beta',
   pagination: {
     defaultPageSize: 30,
-    maxPageSize: 100,
+    maxPageSize: 30,
   },
   queueDelete: {
     queryLimit: 5000,

--- a/src/dataService/savedItemsService.ts
+++ b/src/dataService/savedItemsService.ts
@@ -105,7 +105,7 @@ export class SavedItemDataService {
         `CASE WHEN status = ${SavedItemStatus.DELETED} THEN UNIX_TIMESTAMP(time_updated) ELSE null END as _deletedAt`
       ),
       this.db.raw(
-        `CASE WHEN status = ${SavedItemStatus.ARCHIVED} THEN UNIX_TIMESTAMP(time_updated) ELSE null END as archivedAt`
+        `CASE WHEN status = ${SavedItemStatus.ARCHIVED} THEN UNIX_TIMESTAMP(time_read) ELSE null END as archivedAt`
       )
     );
   }

--- a/src/test/functional/queryServices.test/savedItem.integration.ts
+++ b/src/test/functional/queryServices.test/savedItem.integration.ts
@@ -189,7 +189,7 @@ describe('getSavedItemByItemId', () => {
       true
     );
     expect(archivedRes.data?._entities[0].savedItemById.archivedAt).to.equal(
-      unixDate1
+      getUnixTimestamp(date)
     );
     expect(nonArchivedRes.data?._entities[0].savedItemById.isArchived).to.equal(
       false


### PR DESCRIPTION
## Goal
- Limit pagination maximum to 30
- Correctly use `time_read` as `archivedAt` in the `SavedItem` entity

## References

Jira ticket: INFRA-582
