### PR TITLE
fix: limit lambda concurrency for deleter

### DIFF
--- a/.aws/src/lambda/BatchDeleteLambda.ts
+++ b/.aws/src/lambda/BatchDeleteLambda.ts
@@ -13,6 +13,7 @@ export class BatchDeleteLambda extends Resource {
     new SqsLambda(this, 'Sqs-Batch-Delete-Consumer', {
       vpc: config.vpc,
       batchSize: 1,
+      reservedConcurrencyLimit: 1,
     });
   }
 }

--- a/.aws/src/lambda/base/SqsLambda.ts
+++ b/.aws/src/lambda/base/SqsLambda.ts
@@ -13,6 +13,7 @@ export interface SqsLambdaProps {
   batchSize: number;
   pagerDuty?: PocketPagerDuty;
   alarms?: PocketVersionedLambdaProps['lambda']['alarms'];
+  reservedConcurrencyLimit?: number;
 }
 
 export class SqsLambda extends Resource {
@@ -36,6 +37,7 @@ export class SqsLambda extends Resource {
         runtime: LAMBDA_RUNTIMES.NODEJS16,
         handler: 'index.handler',
         timeout: 120,
+        reservedConcurrencyLimit: config.reservedConcurrencyLimit,
         environment: {
           SENTRY_DSN: sentryDsn,
           GIT_SHA: gitSha,


### PR DESCRIPTION
## Goal

Limit lambda concurrency to avoid db overload