### PR TITLE
chore: reduce queue delete batch size

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -96,7 +96,7 @@ export default {
     maxPageSize: 30,
   },
   queueDelete: {
-    queryLimit: 5000,
-    itemIdChunkSize: 1000,
+    queryLimit: 500,
+    itemIdChunkSize: 100,
   },
 };


### PR DESCRIPTION
## Goal

Reduce batch size of list deletes (number of rows deleted per message) to 100, selecting 500 at a time.
