### PR TITLE
fix: increase sqs visibility config and retention time

### DIFF
--- a/.aws/package.json
+++ b/.aws/package.json
@@ -18,7 +18,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@pocket-tools/terraform-modules": "4.0.2"
+    "@pocket-tools/terraform-modules": "4.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.33",

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -47,6 +47,8 @@ class ListAPI extends TerraformStack {
       tags: config.tags,
       //need to set maxReceiveCount to enable DLQ
       maxReceiveCount: 3,
+      visibilityTimeoutSeconds: 10000,
+      messageRetentionSeconds: 1209600,
     });
 
     const pocketApp = this.createPocketAlbApplication({

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -402,8 +402,8 @@ class ListAPI extends TerraformStack {
           'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
       },
       autoscalingConfig: {
-        targetMinCapacity: 2,
-        targetMaxCapacity: 10,
+        targetMinCapacity: 1,
+        targetMaxCapacity: 1,
       },
       alarms: {
         //TODO: When we start using this more we will change from non-critical to critical

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -56,7 +56,8 @@ export default {
         url:
           process.env.SQS_BATCH_DELETE_QUEUE_URL ||
           'http://localhost:4566/queue/pocket-list-delete-queue',
-        visibilityTimeout: 300,
+        visibilityTimeout: 10000,
+        messageRetentionSeconds: 1209600,
         maxMessages: 1,
         waitTimeSeconds: 0,
         defaultPollIntervalSeconds: 300,


### PR DESCRIPTION
## Goal

Increase sqs visibility timeout so the messages don't reappear in the queue quickly. we do this coz some deletion queries run upto 1000s.

increase message retention time to 14 days (max allowed)

set task count to 1 as this app is used by beta client only for now.. 

### future todo
move the batchDeleteHandler to its own ecs task. so we can scale it down to 1 without affecting the API scaling in a future PR - https://getpocket.atlassian.net/browse/INFRA-662