### PR TITLE
fix: delete one row at a time from list-tables

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -105,4 +105,7 @@ export default {
     queryLimit: 500,
     itemIdChunkSize: 20,
   },
+  batchDelete: {
+    deleteDelayInMilliSec: 20000,
+  },
 };

--- a/src/dataService/savedItemsService.ts
+++ b/src/dataService/savedItemsService.ts
@@ -272,6 +272,7 @@ export class SavedItemDataService {
    * For a given itemId, deletes one row at a time from list related tables and sleeps for X times.
    * Note: we are not wrapping the deletes in a transactions as the deletes are un-related and
    * and we don't want the transaction to get session lock for longer time.
+   * If a single deletion fails, log error and move on to the next record.
    * @param itemIds: the ids of the items to delete from the user's list, along with tags
    * and accompanying metadata
    * @param requestId: optional unique request ID for tracing
@@ -307,7 +308,9 @@ export class SavedItemDataService {
           );
           await setTimeout(config.batchDelete.deleteDelayInMilliSec);
         } catch (error) {
-          const message = `BatchDelete: Error - transaction failed (userId=${this.userId}, requestId=${requestId})`;
+          const message =
+            `BatchDelete: Error deleting from table ${table}` +
+            `for itemId: ${id} for (userId=${this.userId}, requestId=${requestId}).`;
           Sentry.addBreadcrumb({ message });
           Sentry.captureException(error);
           console.log(message);

--- a/src/dataService/savedItemsService.ts
+++ b/src/dataService/savedItemsService.ts
@@ -5,7 +5,6 @@ import { SavedItem, SavedItemStatus, SavedItemUpsertInput } from '../types';
 import config from '../config';
 import { ItemResponse } from '../externalCaller/parserCaller';
 import * as Sentry from '@sentry/node';
-import { item } from '../resolvers/savedItem';
 import { setTimeout } from 'timers/promises';
 
 type DbResult = {
@@ -292,8 +291,8 @@ export class SavedItemDataService {
       'list_shares',
     ];
 
-    for (let id of itemIds) {
-      for (let table of tables) {
+    for (const id of itemIds) {
+      for (const table of tables) {
         try {
           await this.db(table)
             .delete()
@@ -306,7 +305,7 @@ export class SavedItemDataService {
           console.log(
             `deleted row from list tables for ${tables} for user: ${this.userId} and itemId: ${id}`
           );
-          await setTimeout(10000);
+          await setTimeout(config.batchDelete.deleteDelayInMilliSec);
         } catch (error) {
           const message = `BatchDelete: Error - transaction failed (userId=${this.userId}, requestId=${requestId})`;
           Sentry.addBreadcrumb({ message });

--- a/src/test/functional/mutationServices.test/savedItemsMutationService-delete.integration.ts
+++ b/src/test/functional/mutationServices.test/savedItemsMutationService-delete.integration.ts
@@ -8,6 +8,7 @@ import { EventType, ItemsEventEmitter } from '../../../businessEvents';
 import { getUnixTimestamp } from '../../../utils';
 import { getServer } from '../testServerUtil';
 import { SavedItemDataService } from '../../../dataService';
+import config from '../../../config';
 
 chai.use(chaiDateTime);
 
@@ -80,6 +81,7 @@ describe('Delete/Undelete SavedItem: ', () => {
   const date = new Date('2020-10-03 10:20:30');
   const updateDate = new Date(2021, 1, 1, 0, 0); // mock date for insert
   let clock;
+  let batchDeleteDelay;
 
   afterAll(async () => {
     await writeClient().destroy();
@@ -87,6 +89,8 @@ describe('Delete/Undelete SavedItem: ', () => {
   });
 
   beforeAll(() => {
+    batchDeleteDelay = config.batchDelete.deleteDelayInMilliSec;
+    config.batchDelete.deleteDelayInMilliSec = 1;
     // Mock Date.now() to get a consistent date for inserting data
     clock = sinon.useFakeTimers({
       now: updateDate,
@@ -99,6 +103,11 @@ describe('Delete/Undelete SavedItem: ', () => {
     await db('item_tags').truncate();
     await db('item_attribution').truncate();
     await db('items_scroll').truncate();
+  });
+
+  afterAll(() => {
+    //rest config variables
+    config.batchDelete.deleteDelayInMilliSec = batchDeleteDelay;
   });
 
   it('should batch delete saved items', async () => {


### PR DESCRIPTION
## Goal

from testing we observed that mysql sometimes does table-scan instead of delete by primary key index for batch deletes.
so we now delete one row at a time from list related tables 

## Implementation Decisions
- delete one row per table based on itemId
- removed transactions as the deletes are un-related and we want to delete max row possible, and the transcation shouldn't hold a session for a longer time
- sleep for 20 secs before the next delete, to reduce the replication lags in read replicas


slack conversation: https://pocket.slack.com/archives/C03E28D1GUD/p1658190886666469?thread_ts=1658187746.380859&cid=C03E28D1GUD

- [ ] dev testing

