### PR TITLE
fix: task count set to 1 for now

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -401,9 +401,12 @@ class ListAPI extends TerraformStack {
         taskExecutionDefaultAttachmentArn:
           'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
       },
+      //changes done for deletion testing only
+      //todo: we need to scale it back up, or immediately prioritize to move
+      //deletion handler as a separate thread
       autoscalingConfig: {
-        targetMinCapacity: 2,
-        targetMaxCapacity: 10,
+        targetMinCapacity: 1,
+        targetMaxCapacity: 1,
       },
       alarms: {
         //TODO: When we start using this more we will change from non-critical to critical


### PR DESCRIPTION
## Goal

- setting task count to 1 for deletion test in production. we will scale it back up once the metrics look good in prod.
- right now, the app is used by beta iOS clients, and web clients behind a feature flag. 

- [x] should inform clients about this change - https://pocket.slack.com/archives/C01VDFM30J2/p1658258066643759