### PR TITLE
chore: batch delete 50 records every 10 seconds

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -108,10 +108,10 @@ export default {
   },
   queueDelete: {
     queryLimit: 500,
-    itemIdChunkSize: 20,
+    itemIdChunkSize: 50,
   },
   batchDelete: {
-    deleteDelayInMilliSec: 20000,
+    deleteDelayInMilliSec: 10000,
     tablesWithPii: ['item_tags', 'list', 'item_attribution'],
     tablesWithUserIdAlone: [
       'list_meta',


### PR DESCRIPTION
## Goal
if the cpu load is still under 50%, we can look to batch delete 50 records every 10 secs

Ticket: https://getpocket.atlassian.net/browse/INFRA-779