### PR TITLE
chore: delete 100 records every 5 seconds

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -108,10 +108,10 @@ export default {
   },
   queueDelete: {
     queryLimit: 500,
-    itemIdChunkSize: 50,
+    itemIdChunkSize: 100,
   },
   batchDelete: {
-    deleteDelayInMilliSec: 10000,
+    deleteDelayInMilliSec: 5000,
     tablesWithPii: ['item_tags', 'list', 'item_attribution'],
     tablesWithUserIdAlone: [
       'list_meta',


### PR DESCRIPTION
## Goal
delete 100 records every 5 seconds

cpu load is at ~41%
the RAM memory is low
the read latency is also low (1.25 ms)

https://us-east-1.console.aws.amazon.com/rds/home?region=us-east-1#database:id=pocket-db-primary-0-prod-cluster;is-cluster=true;tab=monitoring