### PR TITLE
chore: delete 200 records every 3 secs

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -108,10 +108,10 @@ export default {
   },
   queueDelete: {
     queryLimit: 500,
-    itemIdChunkSize: 100,
+    itemIdChunkSize: 200,
   },
   batchDelete: {
-    deleteDelayInMilliSec: 5000,
+    deleteDelayInMilliSec: 3000,
     tablesWithPii: ['item_tags', 'list', 'item_attribution'],
     tablesWithUserIdAlone: [
       'list_meta',


### PR DESCRIPTION
chore: delete 200 records every 3 secs

Reasoning:
- db load: ~45%
- latency: ~1.25 ms
- freeable memory still at ~48k MB
- performance insight queries: most expensive query time is ~100-200ms, so sleep time 3 sec is well above the time required for the table lock to release