### PR TITLE
fix: reducing to 1 sec and reducing batch size to 250.

### DIFF
--- a/src/aws/batchDeleteHandler.spec.ts
+++ b/src/aws/batchDeleteHandler.spec.ts
@@ -78,7 +78,7 @@ describe('batchDeleteHandler', () => {
         sinon.stub(batchDeleteHandler, 'handleMessage').resolves(true);
         sinon.stub(batchDeleteHandler, 'deleteMessage').resolves();
         await batchDeleteHandler.pollQueue();
-        expect(scheduleStub.calledOnceWithExactly(2000)).toBe(true);
+        expect(scheduleStub.calledOnceWithExactly(1000)).toBe(true);
       });
       it('sends a delete if message was successfully processed', async () => {
         sinon.stub(batchDeleteHandler, 'handleMessage').resolves(true);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -66,7 +66,7 @@ export default {
         maxMessages: 1,
         waitTimeSeconds: 0,
         defaultPollIntervalSeconds: 300,
-        afterMessagePollIntervalSeconds: 2,
+        afterMessagePollIntervalSeconds: 1,
       },
       permLibItemMainQueue: {
         events: [EventType.ADD_ITEM],
@@ -108,7 +108,7 @@ export default {
   },
   queueDelete: {
     queryLimit: 1000,
-    itemIdChunkSize: 500,
+    itemIdChunkSize: 250,
   },
   batchDelete: {
     deleteDelayInMilliSec: 500,


### PR DESCRIPTION
total delay between deletes (1 sec polling delay + 0.5 secs sleep)

db load is at ~10%

we can probably let it run seeing how things are going 
slack thread: https://pocket.slack.com/archives/C03QVL4SU/p1668620128626459?thread_ts=1668618924.659309&cid=C03QVL4SU