### PR TITLE
chore: add more breadcrumbs in data loader to identify items failing

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -66,7 +66,7 @@ export default {
         maxMessages: 1,
         waitTimeSeconds: 0,
         defaultPollIntervalSeconds: 300,
-        afterMessagePollIntervalSeconds: 2,
+        afterMessagePollIntervalSeconds: 1,
       },
       permLibItemMainQueue: {
         events: [EventType.ADD_ITEM],
@@ -108,7 +108,7 @@ export default {
   },
   queueDelete: {
     queryLimit: 1000,
-    itemIdChunkSize: 500,
+    itemIdChunkSize: 250,
   },
   batchDelete: {
     deleteDelayInMilliSec: 500,

--- a/src/dataLoader/savedItemsDataLoader.spec.ts
+++ b/src/dataLoader/savedItemsDataLoader.spec.ts
@@ -1,0 +1,63 @@
+import { SavedItem } from '../types';
+import sinon from 'sinon';
+import { SavedItemDataService } from '../dataService';
+import { batchGetSavedItemsByIds } from './savedItemsDataLoader';
+import { writeClient } from '../database/client';
+
+describe('savedItem data loader', function () {
+  const testSavedItem: SavedItem[] = [
+    {
+      id: '1',
+      resolvedId: '1',
+      url: 'abc.com',
+      isFavorite: false,
+      isArchived: false,
+      status: 'UNREAD',
+      item: {
+        givenUrl: 'abc.com',
+      },
+    },
+    {
+      id: '2',
+      resolvedId: '2',
+      url: 'def.com',
+      isFavorite: false,
+      isArchived: false,
+      status: 'DELETED',
+      item: {
+        givenUrl: 'def.com',
+      },
+    },
+  ];
+  it('should not return deleted items', async () => {
+    const promiseSavedItem = Promise.resolve(testSavedItem);
+    const db = writeClient();
+    const service = new SavedItemDataService({
+      dbClient: db,
+      userId: '1',
+      apiId: 'backend',
+    });
+    sinon
+      .stub(service, 'batchGetSavedItemsByGivenIds')
+      .returns(promiseSavedItem);
+
+    const items = await batchGetSavedItemsByIds(service, ['1', '2']);
+    items.forEach((item) => expect(item.id).not.toBe('2'));
+  });
+
+  it('should not return undefined in the batch for non-existent IDs', async () => {
+    const promiseSavedItem = Promise.resolve(testSavedItem);
+    const db = writeClient();
+    const service = new SavedItemDataService({
+      dbClient: db,
+      userId: '1',
+      apiId: 'backend',
+    });
+    sinon
+      .stub(service, 'batchGetSavedItemsByGivenIds')
+      .returns(promiseSavedItem);
+
+    const items = await batchGetSavedItemsByIds(service, ['1', '3']);
+    items.forEach((item) => expect(item.id).not.toBe('undefined'));
+  });
+});

--- a/src/dataLoader/utils.spec.ts
+++ b/src/dataLoader/utils.spec.ts
@@ -25,6 +25,24 @@ describe('reorder by key', () => {
     const actual = reorderResultByKey<MyObject, 'name'>(orderMapping, results);
     expect(actual).toEqual(expected);
   });
+  it('undefined returned when key is not found', () => {
+    const results: MyObject[] = [
+      {
+        id: 1,
+        name: '1',
+        next: { id: 1, name: '2', next: null },
+      },
+      {
+        id: 2,
+        name: '2',
+        next: null,
+      },
+    ];
+    const expected = [undefined, results[0]];
+    const orderMapping = { key: 'name' as const, values: ['3', '1'] };
+    const actual = reorderResultByKey<MyObject, 'name'>(orderMapping, results);
+    expect(actual).toEqual(expected);
+  });
   it('works with singleton mapping array', () => {
     const results: MyObject[] = [
       {


### PR DESCRIPTION
## Goal

- we are trying to access `url` for an item that doesn't exist
- `reorderResultByKey` could set the item to undefined if the Id is not present in the database or when it got deleted during the batchRead

### Implementation details 
- add to dataloader only when the item is present
- filter the undefined values in both `batchGetSavedItemsByIds` and `batchGetSavedItemsByUrls`
- added test to make sure undefined values and deleted items are filtered out of `item`

### feedback on:
- would this affect how the external service that's consuming from the data loader? as we are removing ids that's not present in our db

Ticket: https://getpocket.atlassian.net/browse/INFRA-803