### PR TITLE
chore: add breadcrumbs to check if any specific action fails

### DIFF
--- a/src/businessEvents/sqs/transformers/index.ts
+++ b/src/businessEvents/sqs/transformers/index.ts
@@ -1,6 +1,7 @@
 import { ItemEventPayload, SQSEvents } from '../../types';
 import config from '../../../config';
 import { mysqlTimeString } from '../../../dataService/utils';
+import * as Sentry from '@sentry/node';
 
 export type EventTransFormer = {
   transformer: (data: ItemEventPayload) => Promise<any>;
@@ -29,6 +30,10 @@ export async function publisherDataSqsTransformer(data: ItemEventPayload) {
   const action = SQSEvents[data.eventType];
 
   if (!action) return null;
+
+  Sentry.addBreadcrumb({
+    message: `action ${action}; userId: ${parseInt(data.user.id)} `,
+  });
 
   return {
     action: action,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -66,7 +66,7 @@ export default {
         maxMessages: 1,
         waitTimeSeconds: 0,
         defaultPollIntervalSeconds: 300,
-        afterMessagePollIntervalSeconds: 2,
+        afterMessagePollIntervalSeconds: 1,
       },
       permLibItemMainQueue: {
         events: [EventType.ADD_ITEM],
@@ -108,7 +108,7 @@ export default {
   },
   queueDelete: {
     queryLimit: 1000,
-    itemIdChunkSize: 500,
+    itemIdChunkSize: 250,
   },
   batchDelete: {
     deleteDelayInMilliSec: 500,


### PR DESCRIPTION
## Goal
chore: add breadcrumbs to check if any specific action fails

checked all mutations. all savedItem mutation actually passes a resolved savedItem. the tag-savedItem association mutations are the one that passes the promise, but the test seem to have covered these getSavedItemById functions.

so adding breadcrumbs to see if there is a specific event that's giving us this error (or) happens randomly for all events

for error: https://sentry.io/organizations/pocket/issues/3464752853/?project=5761820&referrer=project-issue-stream

ticket: https://getpocket.atlassian.net/browse/INFRA-804