### PR TITLE
fix(db): increase max connection pool size

### DIFF
--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -51,7 +51,7 @@ export function createConnection(dbConfig: {
     },
     pool: {
       min: 0, //knex docs state to set to 0 so that idle connections are released. Default was 2 for legacy knex reasons (according to docs)
-      max: 10, //knex default
+      max: 500, // current RDS max connections is 5k (SHOW GLOBAL VARIABLES LIKE 'max_connections)
       /**
        * Explicitly set the session timezone. We don't want to take any chances with this
        */


### PR DESCRIPTION
Testing out increasing the max connection pool. Do not merge until tomorrow.

The current limit on connections is 5000 based on our RDS instance types.

`SHOW GLOBAL VARIABLES LIKE 'max_connections`

