### PR TITLE
fix(item): resolve savedItem on Item [INFRA-778]

### DIFF
--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -22,9 +22,10 @@ import {
   upsertSavedItem,
 } from './mutation';
 import { tagsSavedItems } from './tag';
-import { SavedItem, Tag } from '../types';
+import { Item, SavedItem, Tag } from '../types';
 import { IContext } from '../server/context';
 import { writeClient } from '../database/client';
+import { NotFoundError } from '@pocket-tools/apollo-utils';
 
 const resolvers = {
   ItemResult: {
@@ -38,7 +39,23 @@ const resolvers = {
     tags: userTags,
   },
   Item: {
-    savedItem,
+    savedItem: async (item: Item, args, context: IContext) => {
+      const save = await context.dataLoaders.savedItemsByUrl.load(
+        item.givenUrl
+      );
+      if (save == null) {
+        throw new NotFoundError(`No Save found for url=${item.givenUrl}`);
+      }
+      return save;
+    },
+    // This is basically a passthrough so that the givenUrl is available
+    // on the parent when the savedItem entity is resolved
+    // Possible to resolve savedItem on this reference resolver instead,
+    // but this maintains our pattern of separation of entity resolvers
+    // If other scalar fields were resolved by list on Item, they'd go here
+    __resolveReference: async (item: Item, context: IContext) => {
+      return item;
+    },
   },
   SavedItem: {
     tags: savedItemTags,

--- a/src/test/functional/queryServices.test/item.integration.ts
+++ b/src/test/functional/queryServices.test/item.integration.ts
@@ -1,0 +1,186 @@
+import { getServer } from '../testServerUtil';
+import { readClient } from '../../../database/client';
+import { gql } from 'apollo-server-express';
+
+describe('item', () => {
+  const itemFragment = gql`
+    fragment ItemFields on Item {
+      givenUrl
+      savedItem {
+        id
+        url
+        isFavorite
+        isArchived
+      }
+    }
+  `;
+  const GET_SAVED_ITEM = gql`
+    ${itemFragment}
+    query getSaveFromItem($givenUrl: String!) {
+      _entities(representations: { givenUrl: $givenUrl, __typename: "Item" }) {
+        ... on Item {
+          ...ItemFields
+        }
+      }
+    }
+  `;
+  // It was more effort to format the entity string programmatically
+  // than to just duplicate it
+  const GET_TWO_SAVED_ITEMS = gql`
+    ${itemFragment}
+    query getSavesFromItems($givenUrl1: String!, $givenUrl2: String!) {
+      _entities(
+        representations: [
+          { givenUrl: $givenUrl1, __typename: "Item" }
+          { givenUrl: $givenUrl2, __typename: "Item" }
+        ]
+      ) {
+        ... on Item {
+          ...ItemFields
+        }
+      }
+    }
+  `;
+  const db = readClient();
+  const server = getServer('1', db, null);
+  const date = new Date('2020-10-03 10:20:30'); // Consistent date for seeding
+  const date1 = new Date('2020-10-03 10:30:30'); // Consistent date for seeding
+
+  beforeAll(async () => {
+    await db('list').truncate();
+    await db('list').insert([
+      {
+        // a valid item_url
+        user_id: 1,
+        item_id: 1,
+        resolved_id: 1,
+        given_url: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+        title: 'mytitle',
+        time_added: date,
+        time_updated: date1,
+        time_read: date,
+        time_favorited: date,
+        api_id: 'apiid',
+        status: 0,
+        favorite: 1,
+        api_id_updated: 'apiid',
+      },
+      {
+        // a valid item_url
+        user_id: 1,
+        item_id: 999,
+        resolved_id: 999,
+        given_url: 'https://www.youtube.com/watch?v=OZaL86RDGIU',
+        title: 'mytitle2',
+        time_added: date,
+        time_updated: date1,
+        time_read: date,
+        time_favorited: date,
+        api_id: 'apiid',
+        status: 1,
+        favorite: 0,
+        api_id_updated: 'apiid',
+      },
+      {
+        // a valid item_url but not for the user
+        user_id: 2,
+        item_id: 2,
+        resolved_id: 2,
+        given_url: 'https://www.youtube.com/watch?v=Tpbo25iBvfU',
+        title: 'title2',
+        time_added: date,
+        time_updated: date1,
+        time_read: date,
+        time_favorited: date,
+        api_id: 'apiid',
+        status: 0,
+        favorite: 1,
+        api_id_updated: 'apiid',
+      },
+    ]);
+  });
+  it('resolves more than one savedItem from multiple entities', async () => {
+    const expected = [
+      {
+        givenUrl: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+        savedItem: {
+          url: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+          isFavorite: true,
+          isArchived: false,
+          id: '1',
+        },
+      },
+      {
+        givenUrl: 'https://www.youtube.com/watch?v=OZaL86RDGIU',
+        savedItem: {
+          url: 'https://www.youtube.com/watch?v=OZaL86RDGIU',
+          isFavorite: false,
+          isArchived: true,
+          id: '999',
+        },
+      },
+    ];
+    const variables = {
+      userId: '1',
+      givenUrl1: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+      givenUrl2: 'https://www.youtube.com/watch?v=OZaL86RDGIU',
+    };
+
+    const res = await server.executeOperation({
+      query: GET_TWO_SAVED_ITEMS,
+      variables,
+    });
+    expect(res.errors).toBeUndefined;
+    expect(res.data).not.toBeUndefined;
+    const entities = res.data._entities;
+    expect(entities.length).toEqual(2);
+    expect(entities).toEqual(expect.arrayContaining(expected));
+  });
+  it('resolves savedItem field from entity representation', async () => {
+    const expected = {
+      givenUrl: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+      savedItem: {
+        url: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+        isFavorite: true,
+        isArchived: false,
+        id: '1',
+      },
+    };
+    const variables = {
+      userId: '1',
+      givenUrl: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+    };
+
+    const res = await server.executeOperation({
+      query: GET_SAVED_ITEM,
+      variables,
+    });
+
+    expect(res.errors).toBeUndefined;
+    expect(res.data).not.toBeUndefined;
+    const entities = res.data._entities;
+    expect(entities.length).toEqual(1);
+    expect(entities[0]).toEqual(expected);
+  });
+  it('returns null with not found error if the save does not exist', async () => {
+    const variables = {
+      userId: '1',
+      givenUrl: 'https://www.youtube.com/watch?v=Tpbo25iBvfU',
+    };
+
+    const res = await server.executeOperation({
+      query: GET_SAVED_ITEM,
+      variables,
+    });
+    expect(res.data).not.toBeUndefined;
+    expect(res.errors).not.toBeUndefined;
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].extensions.code).toEqual('NOT_FOUND');
+    const entities = res.data._entities;
+    expect(entities.length).toEqual(1);
+    expect(entities[0].givenUrl).toEqual(
+      'https://www.youtube.com/watch?v=Tpbo25iBvfU'
+    );
+    expect(entities[0].savedItem).toBeNull;
+  });
+});


### PR DESCRIPTION
# Goal

Fixes bug where itemByItemId and itemByItemUrl
queries attempting to fetch savedItem field
on Item always returned null

Conceptually this is because we're resolving an `Item` field (`Item.savedItem`) on the list subgraph, but we didn't actually define a reference resolver. The key for the entity is available via federation, but it needs the reference resolver in order to get passed down to the rest of the resolver chain.

## Implementation decisions
- Replaced old data service call with dataloader in `Item.savedItem` resolver

## References

Jira ticket:
* [INFRA-778]

