### PR TITLE
chore: bring back account deletion

### DIFF
--- a/src/aws/batchDeleteHandler.spec.ts
+++ b/src/aws/batchDeleteHandler.spec.ts
@@ -33,12 +33,12 @@ describe('batchDeleteHandler', () => {
     const eventSpy = sinon.spy(emitter, 'emit');
     sinon.stub(BatchDeleteHandler.prototype, 'pollQueue').resolves();
     new BatchDeleteHandler(emitter);
-    expect(eventSpy.calledOnceWithExactly('pollBatchDelete')).toBe(false);
+    expect(eventSpy.calledOnceWithExactly('pollBatchDelete')).toBe(true);
   });
   it('invokes listener when pollBatchDelete event is emitted', async () => {
     const listenerStub = sinon.stub(batchDeleteHandler, 'pollQueue').resolves();
     emitter.emit('pollBatchDelete');
-    expect(listenerStub.callCount).toEqual(0);
+    expect(listenerStub.callCount).toEqual(1);
   });
   it('schedules a poll event after some time if no messages returned', async () => {
     sinon.stub(SQSClient.prototype, 'send').resolves({ Messages: [] });

--- a/src/aws/batchDeleteHandler.spec.ts
+++ b/src/aws/batchDeleteHandler.spec.ts
@@ -78,7 +78,7 @@ describe('batchDeleteHandler', () => {
         sinon.stub(batchDeleteHandler, 'handleMessage').resolves(true);
         sinon.stub(batchDeleteHandler, 'deleteMessage').resolves();
         await batchDeleteHandler.pollQueue();
-        expect(scheduleStub.calledOnceWithExactly(30000)).toBe(true);
+        expect(scheduleStub.calledOnceWithExactly(1000)).toBe(true);
       });
       it('sends a delete if message was successfully processed', async () => {
         sinon.stub(batchDeleteHandler, 'handleMessage').resolves(true);

--- a/src/aws/batchDeleteHandler.ts
+++ b/src/aws/batchDeleteHandler.ts
@@ -48,14 +48,14 @@ export class BatchDeleteHandler {
       endpoint: config.aws.endpoint,
       maxAttempts: 3,
     });
-    // emitter.on(
-    //   BatchDeleteHandler.eventName,
-    //   async () => await this.pollQueue()
-    // );
+    emitter.on(
+      BatchDeleteHandler.eventName,
+      async () => await this.pollQueue()
+    );
     // Start the polling by emitting an initial event
-    // if (pollOnInit) {
-    //   emitter.emit(BatchDeleteHandler.eventName);
-    // }
+    if (pollOnInit) {
+      emitter.emit(BatchDeleteHandler.eventName);
+    }
   }
 
   /**
@@ -119,7 +119,7 @@ export class BatchDeleteHandler {
     if (timeout > 0) {
       await setTimeout(timeout);
     }
-    //this.emitter.emit(BatchDeleteHandler.eventName);
+    this.emitter.emit(BatchDeleteHandler.eventName);
   }
 
   /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -74,7 +74,7 @@ export default {
         maxMessages: 1,
         waitTimeSeconds: 0,
         defaultPollIntervalSeconds: 300,
-        afterMessagePollIntervalSeconds: 30,
+        afterMessagePollIntervalSeconds: 1,
       },
       permLibItemMainQueue: {
         events: [EventType.ADD_ITEM],
@@ -117,10 +117,10 @@ export default {
   },
   queueDelete: {
     queryLimit: 1000,
-    itemIdChunkSize: 20,
+    itemIdChunkSize: 250,
   },
   batchDelete: {
-    deleteDelayInMilliSec: 10000,
+    deleteDelayInMilliSec: 500,
     tablesWithPii: ['item_tags', 'list', 'item_attribution'],
     tablesWithUserIdAlone: [
       'list_meta',

--- a/src/dataService/savedItemsService.ts
+++ b/src/dataService/savedItemsService.ts
@@ -280,34 +280,32 @@ export class SavedItemDataService {
   public async batchDeleteSavedItems(itemIds: number[], requestId?: string) {
     const tables = [...config.batchDelete.tablesWithPii];
 
-    for (const id of itemIds) {
-      for (const table of tables) {
-        try {
-          await this.db(table)
-            .delete()
-            .where('item_id', id)
-            .andWhere({ user_id: this.userId });
+    for (const table of tables) {
+      try {
+        await this.db(table)
+          .delete()
+          .whereIn('item_id', itemIds)
+          .andWhere({ user_id: this.userId });
 
-          if (requestId) {
-            console.log(`BatchDelete: Processing request ID=${requestId}`);
-          }
-          console.log(
-            `BatchDelete: deleted row from table: ${table} for user: ${
-              this.userId
-            } and itemIds: ${JSON.stringify(itemIds)}`
-          );
-          await setTimeout(config.batchDelete.deleteDelayInMilliSec);
-        } catch (error) {
-          const message =
-            `BatchDelete: Error deleting from table ${table}` +
-            `for itemId:  ${JSON.stringify(itemIds)} for (userId=${
-              this.userId
-            }, requestId=${requestId}).`;
-          Sentry.addBreadcrumb({ message });
-          Sentry.captureException(error);
-          console.log(message);
-          console.log(error);
+        if (requestId) {
+          console.log(`BatchDelete: Processing request ID=${requestId}`);
         }
+        console.log(
+          `BatchDelete: deleted row from table: ${table} for user: ${
+            this.userId
+          } and itemIds: ${JSON.stringify(itemIds)}`
+        );
+        await setTimeout(config.batchDelete.deleteDelayInMilliSec);
+      } catch (error) {
+        const message =
+          `BatchDelete: Error deleting from table ${table}` +
+          `for itemId:  ${JSON.stringify(itemIds)} for (userId=${
+            this.userId
+          }, requestId=${requestId}).`;
+        Sentry.addBreadcrumb({ message });
+        Sentry.captureException(error);
+        console.log(message);
+        console.log(error);
       }
     }
   }


### PR DESCRIPTION
## Goal
Earlier we paused deletion of list-items as we were seeing increase in db load in replicas, and this was caused due to increase in metric `RollbackSegmentHistoryListLength`

Recent investigations by SRE team shows feed-machine queries were causing high HLL, so we are re-activating the deletion pipeline in list-api

https://pocket.slack.com/archives/C01CLPFMJJ1/p1670435709030319
https://pocket.slack.com/archives/C01CLPFMJJ1/p1670446585409359
