### PR TITLE
feat(PocketSave): Create a PocketSave entity that is retrievable by ID for now

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,9 @@
+"""
+ISOString scalar - all datetimes fields are Typescript Date objects on this server &
+returned as ISO-8601 encoded date strings (e.g. ISOString scalars) to GraphQL clients.
+See Section 5.6 of the RFC 3339 profile of the ISO 8601 standard: https://www.ietf.org/rfc/rfc3339.txt.
+"""
 scalar ISOString
-
-scalar Markdown
 
 scalar Url
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,7 @@
+scalar ISOString
+
+scalar Markdown
+
 scalar Url
 
 """
@@ -495,6 +499,11 @@ extend type User @key(fields: "id") {
   Get a SavedItem by its id
   """
   savedItemById(id: ID!): SavedItem
+
+  """
+  Get a PocketSave by its id
+  """
+  pocketSaveById(id: ID!): PocketSave
 }
 
 """
@@ -620,3 +629,145 @@ type Mutation {
   """
   replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
 }
+
+# """
+
+# PocketSave Entities (a rework of SavedItem) starts here.
+
+# """
+
+"""
+Enum to specify the PocketSave Status (mapped to integers in data store).
+"""
+enum PocketSaveStatus {
+  ARCHIVED
+  DELETED
+  HIDDEN
+  UNREAD
+}
+
+"""
+New Pocket Save Type, replacing SavedItem.
+
+Represents a Pocket Item that a user has saved to their list.
+(Said otherways, indicates a saved url to a users list and associated user specific information.)
+"""
+type PocketSave {
+  # Not resolved on this subgraph.
+  # """
+  # Authors credited for content.
+  # """
+  # authors: [Authors!]
+
+  """
+  Indicates if the PocketSave is archived.
+  """
+  archived: Boolean!
+
+  """
+  Timestamp that the PocketSave became archived, null if not archived.
+  """
+  archivedAt: ISOString
+
+  """
+  Unix timestamp of when the PocketSave was created.
+  """
+  createdAt: ISOString!
+
+  """
+  Unix timestamp of when the entity was deleted.
+  """
+  deletedAt: ISOString
+
+  # Not resolved on this subgraph.
+  # """
+  # Excerpt from text content, typically the first paragraph.
+  # """
+  # excerpt: Markdown
+
+  """
+  Indicates if the PocketSave is favorited.
+  """
+  favorite: Boolean!
+
+  """
+  Timestamp that the PocketSave became favorited, null if not favorited.
+  """
+  favoritedAt: ISOString
+
+  """
+  The url the user gave (as opposed to normalized URLs).
+  """
+  givenUrl: String!
+
+  """
+  Surrogate primary key.
+  """
+  id: ID!
+
+  # Not resolved on this subgraph.
+  # """
+  # Reference to the underlying Resource that this PocketSave metadata is about.
+  # """
+  # resource: PocketResource!
+
+  # Not resolved on this subgraph.
+  # """
+  # The web site publisher; defaults to the domain of the PocketSave URL.
+  # """
+  # source: String!
+
+  """
+  The status of this PocketSave; Marked for review for possible removal.
+  """
+  status: PocketSaveStatus
+
+  """
+  The Suggested Tags associated with this PocketSave, if the user is not premium or there are none, this will be empty.
+  """
+  suggestedTags: [Tag!]
+
+  """
+  The Tags associated with this PocketSave.
+  """
+  tags: [Tag!]
+
+  # Not resolved on this subgraph.
+  # """
+  # Direction text should be displayed, e.g. right-to-left; an enum.
+  # """
+  # textDirection: TextDirection
+
+  # Not resolved on this subgraph.
+  # """
+  # Image to display as thumbnail.
+  # """
+  # thumbnail: Image
+
+  # Not resolved on this subgraph.
+  # """
+  # Estimated time to consume content, rounded to the nearest minute.
+  # """
+  # timeToConsume: Int
+
+  """
+  The title of the Resource; defaults to the URL.
+  """
+  title: String!
+
+  """
+  Unix timestamp of when the PocketSave was last updated, if any property on the PocketSave is modified this timestamp is set to the modified time.
+  """
+  updatedAt: ISOString
+}
+
+# To be setup: connect PocketSaves to a new entity - PocketResource
+# extend type PocketResource @key(fields: "itemId") {
+#   "key field to identify the PocketResource entity in the Parser service"
+#   itemId: ID! @external
+
+#   """
+#   Identify if the given PocketResource is in the user's list.
+#   """
+#   pocketSave: PocketSave
+# }

--- a/src/dataService/index.ts
+++ b/src/dataService/index.ts
@@ -1,4 +1,5 @@
+export * from './listPaginationService';
+export * from './pocketSavesService';
 export * from './savedItemsService';
 export * from './tagDataService';
 export * from './usersMetaService';
-export * from './listPaginationService';

--- a/src/dataService/pocketSavesService.spec.ts
+++ b/src/dataService/pocketSavesService.spec.ts
@@ -1,0 +1,58 @@
+import { PocketSaveDataService, RawListResult } from './pocketSavesService';
+
+const dateAdded = new Date('2008-10-21 13:57:01');
+const dateFavorited = new Date('0000-00-00 00:00:00');
+const dateRead = new Date('2008-10-21 14:00:01');
+const dateUpdated = new Date('2012-08-13 15:32:05');
+
+const rawListResult: RawListResult = {
+  api_id: '123',
+  api_id_updated: 0,
+  favorite: 0,
+  given_url: 'http://www.ideashower.com/',
+  item_id: 5,
+  resolved_id: 5,
+  status: 0,
+  time_added: dateAdded,
+  time_favorited: dateFavorited,
+  time_read: dateRead,
+  time_updated: dateUpdated,
+  title: 'the Idea Shower',
+  user_id: 1,
+};
+
+describe('PocketSaveDataService', () => {
+  describe('convertListResult', () => {
+    it('converts 0 to UNREAD', () => {
+      const result = PocketSaveDataService.convertListResult(rawListResult);
+      expect(result.status).toStrictEqual('UNREAD');
+    });
+    it('converts 1 to ARCHIVED', () => {
+      rawListResult.status = 1;
+      const result = PocketSaveDataService.convertListResult(rawListResult);
+      expect(result.status).toStrictEqual('ARCHIVED');
+    });
+    it('converts 2 to DELETED', () => {
+      rawListResult.status = 2;
+      const result = PocketSaveDataService.convertListResult(rawListResult);
+      expect(result.status).toStrictEqual('DELETED');
+    });
+    it('converts 3 to HIDDEN', () => {
+      rawListResult.status = 3;
+      const result = PocketSaveDataService.convertListResult(rawListResult);
+      expect(result.status).toStrictEqual('HIDDEN');
+    });
+    it('null in null out', () => {
+      const result = PocketSaveDataService.convertListResult(null);
+      expect(result).toStrictEqual(null);
+    });
+    it('handles stupid "0000-00-00 00:00:00" dates', () => {
+      const result = PocketSaveDataService.convertListResult(rawListResult);
+      expect(result.time_favorited).toStrictEqual(null);
+    });
+    it('handles good non-0 dates', () => {
+      const result = PocketSaveDataService.convertListResult(rawListResult);
+      expect(result.time_added).toStrictEqual(dateAdded);
+    });
+  });
+});

--- a/src/dataService/pocketSavesService.ts
+++ b/src/dataService/pocketSavesService.ts
@@ -1,0 +1,155 @@
+import { Knex } from 'knex';
+import { IContext } from '../server/context';
+import { PocketSaveStatus } from '../types';
+
+export type RawListResult = {
+  api_id: string;
+  api_id_updated: number;
+  favorite: number;
+  given_url: string;
+  item_id: number;
+  resolved_id: number;
+  status: number;
+  time_added: Date;
+  time_favorited: Date;
+  time_read: Date;
+  time_updated: Date;
+  title: string;
+  user_id: number;
+};
+
+export type ListResult = {
+  api_id: string;
+  api_id_updated: number;
+  favorite: number;
+  given_url: string;
+  item_id: number;
+  resolved_id: number;
+  status: keyof typeof PocketSaveStatus;
+  time_added: Date;
+  time_favorited: Date;
+  time_read: Date;
+  time_updated: Date;
+  title: string;
+  user_id: number;
+};
+
+/***
+ * class that handles the read and write from `readitla-temp.list` table
+ * note: for mutations, please pass the writeClient, otherwise there will be replication lags.
+ */
+export class PocketSaveDataService {
+  private db: Knex;
+  private readonly apiId: string;
+  private readonly userId: string;
+  private static statusMap = {
+    [PocketSaveStatus.UNREAD]: 'UNREAD',
+    [PocketSaveStatus.ARCHIVED]: 'ARCHIVED',
+    [PocketSaveStatus.DELETED]: 'DELETED',
+    [PocketSaveStatus.HIDDEN]: 'HIDDEN',
+  };
+
+  constructor(context: Pick<IContext, 'apiId' | 'dbClient' | 'userId'>) {
+    this.apiId = context.apiId;
+    this.db = context.dbClient;
+    this.userId = context.userId;
+  }
+
+  public static convertListResult(listResult: null): null;
+  public static convertListResult(listResult: RawListResult): ListResult;
+  public static convertListResult(listResult: RawListResult[]): ListResult[];
+  /**
+   * Convert the `status` field in the list table to the expected
+   * GraphQL ENUM string
+   * @param listResult
+   */
+  public static convertListResult(
+    listResult: RawListResult | RawListResult[] | null
+  ): ListResult | ListResult[] | null {
+    if (listResult == null) {
+      return null;
+    }
+
+    const statusConvert = (row: RawListResult) => {
+      console.log(typeof row.time_favorited);
+      const result: ListResult = {
+        api_id: row.api_id,
+        api_id_updated: row.api_id_updated,
+        favorite: row.favorite,
+        given_url: row.given_url,
+        item_id: row.item_id,
+        resolved_id: row.resolved_id,
+        status: PocketSaveDataService.statusMap[row.status],
+        time_added:
+          row.time_added instanceof Date
+            ? !isNaN(row.time_added.getTime())
+              ? row.time_added
+              : null
+            : null,
+        time_favorited:
+          row.time_favorited instanceof Date
+            ? !isNaN(row.time_favorited.getTime())
+              ? row.time_favorited
+              : null
+            : null,
+        time_read:
+          row.time_read instanceof Date
+            ? !isNaN(row.time_read.getTime())
+              ? row.time_read
+              : null
+            : null,
+        time_updated:
+          row.time_updated instanceof Date
+            ? !isNaN(row.time_updated.getTime())
+              ? row.time_updated
+              : null
+            : null,
+        title: row.title,
+        user_id: row.user_id,
+      };
+      return result;
+    };
+
+    if (listResult instanceof Array) {
+      return listResult.map((row) => statusConvert(row));
+    }
+    return statusConvert(listResult);
+  }
+
+  /**
+   * Helper function to build repeated queries, for DRY pocketSave and pocketSaves fetches.
+   * Will eventually be extended for building filter, sorts, etc. for different pagination, etc.
+   * For now just to reuse the same query and reduce testing burden :)
+   */
+  public buildQuery(): any {
+    return this.db('list').select(
+      'api_id',
+      'api_id_updated',
+      'favorite',
+      'given_url',
+      'item_id',
+      'resolved_id',
+      'status',
+      'time_added',
+      'time_favorited',
+      'time_read',
+      'time_updated',
+      'title',
+      'user_id'
+    );
+  }
+
+  /**
+   * Fetch a List Table Row By ID (user id x item_id)
+   * @param itemId the pocketSave ID to fetch
+   */
+  public async getListRowById(itemId: string): Promise<ListResult> {
+    const query = await this.buildQuery()
+      .where({ user_id: this.userId, item_id: itemId })
+      .first();
+
+    const rawResp = query;
+    const resp = PocketSaveDataService.convertListResult(rawResp);
+    return resp;
+  }
+}

--- a/src/dataService/pocketSavesService.ts
+++ b/src/dataService/pocketSavesService.ts
@@ -66,7 +66,7 @@ export class PocketSaveDataService {
   public static convertListResult(
     listResult: RawListResult | RawListResult[] | null
   ): ListResult | ListResult[] | null {
-    if (listResult == null) {
+    if (listResult === undefined || listResult === null) {
       return null;
     }
 

--- a/src/dataService/tagDataService.ts
+++ b/src/dataService/tagDataService.ts
@@ -3,6 +3,7 @@ import { IContext } from '../server/context';
 import { knexPaginator as paginate } from '@pocket-tools/apollo-cursor-pagination';
 import {
   Pagination,
+  PocketSave,
   SavedItem,
   SaveTagNameConnection,
   Tag,
@@ -101,7 +102,7 @@ export class TagDataService {
    Returns the latest 3 tags used by the Pocket User
    TODO: DataLoader
    */
-  public async getSuggestedTags(save: SavedItem): Promise<Tag[]> {
+  public async getSuggestedTags(save: SavedItem | PocketSave): Promise<Tag[]> {
     const existingTags = this.db('item_tags')
       .select('tag')
       .where({ user_id: parseInt(this.userId), item_id: parseInt(save.id) });

--- a/src/dataService/utils.spec.ts
+++ b/src/dataService/utils.spec.ts
@@ -1,7 +1,28 @@
 import { expect } from 'chai';
-import { mysqlTimeString } from './utils';
+import { mysqlDateConvert, mysqlTimeString } from './utils';
 
-describe('mysql timestamp', () => {
+const dateGood = new Date('2008-11-03 08:51:01');
+const dateNull = new Date('0000-00-00 00:00:00');
+
+describe('mysqlDateConvert', () => {
+  it('valid date in, valid date out', () => {
+    const result = mysqlDateConvert(dateGood);
+    expect(result).to.equal(dateGood);
+  });
+  it('invalid 0000-00-00 date in, null out', () => {
+    const result = mysqlDateConvert(dateNull);
+    expect(result).to.equal(null);
+  });
+  it('invalid string in, null out', () => {
+    const result = mysqlDateConvert('notadate');
+    expect(result).to.equal(null);
+  });
+  it('null in, null out', () => {
+    const result = mysqlDateConvert(null);
+    expect(result).to.equal(null);
+  });
+});
+describe('mysqlTimeString', () => {
   it('should convert to timestamp string in proper timezone', () => {
     const expected = '2021-07-28 11:19:15';
     const timestamp = new Date(1627489155000);

--- a/src/dataService/utils.ts
+++ b/src/dataService/utils.ts
@@ -12,3 +12,16 @@ export function mysqlTimeString(timestamp: Date, tz: string): string {
   const dt = DateTime.fromMillis(timestamp.getTime()).setZone(tz);
   return dt.toFormat('yyyy-MM-dd HH:mm:ss');
 }
+
+/**
+ * Convert MySQL Date fields to Typescript Date objects
+ * or null if the MySQL Date field is invalied for Typescript Dates
+ * (e.g. "0000-00-00 00:00:00").
+ * @param mysqlDate the date value from MySQL (could be Date, NaN, or string)
+ */
+export function mysqlDateConvert(mysqlDate: Date | string | null): Date | null {
+  if (mysqlDate instanceof Date && !isNaN(mysqlDate.getTime())) {
+    return mysqlDate;
+  }
+  return null;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,1 +1,2 @@
 export { TagModel } from './tag';
+export { PocketSaveModel } from './pocketSave';

--- a/src/models/pocketSave.spec.ts
+++ b/src/models/pocketSave.spec.ts
@@ -1,0 +1,79 @@
+import { ListResult } from '../dataService/index';
+import { PocketSaveModel } from './index';
+import { PocketSave } from '../types';
+
+const dateAdded = new Date('2008-10-21 13:57:01');
+const dateFavorited = null;
+const dateRead = new Date('2008-10-21 14:00:01');
+const dateUpdated = new Date('2012-08-13 15:32:05');
+
+describe('PocketSaveModel', () => {
+  describe('transformListRow', () => {
+    it('transform takes ListResult & Returns PocketSave', () => {
+      const input: ListResult = {
+        api_id: '1',
+        api_id_updated: 1,
+        favorite: 0,
+        given_url: 'https://puppies.com',
+        item_id: 1,
+        resolved_id: 1,
+        status: 'UNREAD',
+        time_added: dateAdded,
+        time_favorited: dateFavorited,
+        time_read: dateRead,
+        time_updated: dateUpdated,
+        title: 'puppies',
+        user_id: 1,
+      };
+      const output = PocketSaveModel.transformListRow(input);
+      const expected: PocketSave = {
+        archived: false,
+        archivedAt: null,
+        createdAt: new Date('2008-10-21 13:57:01'),
+        deletedAt: null,
+        favorite: false,
+        favoritedAt: null,
+        givenUrl: 'https://puppies.com',
+        id: '1',
+        status: 'UNREAD',
+        title: 'puppies',
+        updatedAt: new Date('2012-08-13 15:32:05'),
+      };
+      expect(output).toStrictEqual(expected);
+    });
+  });
+  describe('transformListRow', () => {
+    it('transform handles status-driven dates', () => {
+      const input: ListResult = {
+        api_id: '1',
+        api_id_updated: 1,
+        favorite: 1,
+        given_url: 'https://puppies.com',
+        item_id: 1,
+        resolved_id: 1,
+        status: 'ARCHIVED',
+        time_added: dateAdded,
+        time_favorited: dateFavorited,
+        time_read: dateRead,
+        time_updated: dateUpdated,
+        title: 'puppies',
+        user_id: 1,
+      };
+      const output = PocketSaveModel.transformListRow(input);
+      const expected: PocketSave = {
+        archived: true,
+        archivedAt: dateRead,
+        createdAt: dateAdded,
+        deletedAt: null,
+        favorite: true,
+        favoritedAt: null,
+        givenUrl: 'https://puppies.com',
+        id: '1',
+        status: 'ARCHIVED',
+        title: 'puppies',
+        updatedAt: dateUpdated,
+      };
+      expect(output).toStrictEqual(expected);
+    });
+  });
+});

--- a/src/models/pocketSave.ts
+++ b/src/models/pocketSave.ts
@@ -1,0 +1,48 @@
+import { PocketSave } from '../types';
+import { IContext } from '../server/context';
+import { ListResult, PocketSaveDataService } from '../dataService';
+import { NotFoundError } from '@pocket-tools/apollo-utils';
+
+export class PocketSaveModel {
+  private saveService: PocketSaveDataService;
+  constructor(public readonly context: IContext) {
+    this.saveService = new PocketSaveDataService(this.context);
+  }
+
+  /**
+   * Transform List Row into PocketSave
+   * @param row the List Table Row to transform
+   */
+  static transformListRow(row: ListResult): PocketSave {
+    const result: PocketSave = {
+      archived: row.status === 'ARCHIVED' ? true : false,
+      archivedAt: row.status === 'ARCHIVED' ? row.time_read : null,
+      createdAt: row.time_added,
+      deletedAt: row.status === 'DELETED' ? row.time_updated : null,
+      favorite: row.favorite === 1 ? true : false,
+      favoritedAt: row.favorite === 1 ? row.time_favorited : null,
+      givenUrl: row.given_url,
+      id: row.item_id.toString(),
+      status: row.status,
+      title: row.title,
+      updatedAt: row.time_updated,
+    };
+
+    return result;
+  }
+
+  /**
+   * * Fetch a PocketSave by its ID
+   * * @param id the ID of the PocketSave to retrieve
+   * @throws NotFoundError if the PocketSave does not exist
+   * @returns the PocketSave entity
+   */
+  public async getById(id: string): Promise<PocketSave> {
+    const listRow = await this.saveService.getListRowById(id);
+    if (listRow == null) {
+      throw new NotFoundError(`Saved Item with ID=${id} does not exist.`);
+    }
+    const pocketSave = PocketSaveModel.transformListRow(listRow);
+    return pocketSave;
+  }
+}

--- a/src/models/pocketSave.ts
+++ b/src/models/pocketSave.ts
@@ -39,7 +39,7 @@ export class PocketSaveModel {
    */
   public async getById(id: string): Promise<PocketSave> {
     const listRow = await this.saveService.getListRowById(id);
-    if (listRow == null) {
+    if (listRow === undefined || listRow === null) {
       throw new NotFoundError(`Saved Item with ID=${id} does not exist.`);
     }
     const pocketSave = PocketSaveModel.transformListRow(listRow);

--- a/src/models/tag.spec.ts
+++ b/src/models/tag.spec.ts
@@ -6,6 +6,8 @@ import { strings } from 'locutus/php';
 
 chai.use(deepEqualInAnyOrder);
 describe('tag model', () => {
+  // write test for getSuggestedTags checking isPremium conditional
+
   describe('id', () => {
     it('should encode name + suffix into an id', () => {
       const expected = 'Y2FsZXZpX194cGt0eHRhZ3hfXw==';

--- a/src/models/tag.spec.ts
+++ b/src/models/tag.spec.ts
@@ -6,8 +6,6 @@ import { strings } from 'locutus/php';
 
 chai.use(deepEqualInAnyOrder);
 describe('tag model', () => {
-  // write test for getSuggestedTags checking isPremium conditional
-
   describe('id', () => {
     it('should encode name + suffix into an id', () => {
       const expected = 'Y2FsZXZpX194cGt0eHRhZ3hfXw==';
@@ -30,7 +28,6 @@ describe('tag model', () => {
       expect(tagModel.TagModel.decodeId(id)).to.equal('lee');
     });
   });
-
   describe('deduplicateInput', () => {
     it('should remove duplicates', () => {
       const inputData: TagCreateInput[] = [

--- a/src/models/tag.spec.ts
+++ b/src/models/tag.spec.ts
@@ -3,9 +3,54 @@ import { TagCreateInput } from '../types';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
 import * as tagModel from './tag';
 import { strings } from 'locutus/php';
+import { ContextManager, IContext } from '../server/context';
+import { Knex } from 'knex';
+import { PocketSave, Tag } from '../types';
+import { TagDataService } from '../dataService';
+
+const tagServiceResp: Tag[] = [
+  { name: 'zebra', id: 'emVicmFfX3hwa3R4dGFneF9f' },
+  { name: 'travel', id: 'dHJhdmVsX194cGt0eHRhZ3hfXw==' },
+];
 
 chai.use(deepEqualInAnyOrder);
 describe('tag model', () => {
+  describe('getSuggestedBySaveId', () => {
+    beforeAll(() => {
+      jest
+        .spyOn(TagDataService.prototype, 'getSuggestedTags')
+        .mockResolvedValue(tagServiceResp);
+    });
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+    it('premium user gets tags', async () => {
+      let parent: PocketSave;
+      const context: IContext = new ContextManager({
+        request: {
+          headers: { userid: '1', apiid: '0', premium: 'true' },
+        },
+        dbClient: jest.fn() as unknown as Knex,
+        eventEmitter: null,
+      });
+      const resp = context.models.tag.getSuggestedBySaveId(parent);
+      const data = await resp;
+      return expect(data).to.deep.equal(tagServiceResp);
+    });
+    it('non-premium user gets no tags', async () => {
+      let parent: PocketSave;
+      const context: IContext = new ContextManager({
+        request: {
+          headers: { userid: '1', apiid: '0', premium: 'false' },
+        },
+        dbClient: jest.fn() as unknown as Knex,
+        eventEmitter: null,
+      });
+      const resp = context.models.tag.getSuggestedBySaveId(parent);
+      const data = await resp;
+      return expect(data).to.deep.equal([]);
+    });
+  });
   describe('id', () => {
     it('should encode name + suffix into an id', () => {
       const expected = 'Y2FsZXZpX194cGt0eHRhZ3hfXw==';

--- a/src/models/tag.ts
+++ b/src/models/tag.ts
@@ -144,7 +144,7 @@ export class TagModel {
    * Get paginated saved item tags
    * @param parent
    */
-  public getSuggestedBySaveId(parent: PocketSave) {
+  public async getSuggestedBySaveId(parent: PocketSave): Promise<Tag[] | []> {
     if (!this.context.userIsPremium) {
       // Suggested Tags is a premium feature.
       return [];

--- a/src/models/tag.ts
+++ b/src/models/tag.ts
@@ -8,6 +8,7 @@ import {
   TagUpdateInput,
   SavedItemTagsInput,
   DeleteSaveTagResponse,
+  PocketSave,
 } from '../types';
 import config from '../config';
 import { IContext } from '../server/context';
@@ -137,6 +138,19 @@ export class TagModel {
 
   public async getBySaveId(id: string): Promise<Tag[]> {
     return this.tagService.getTagsByUserItem(id);
+  }
+
+  /**
+   * Get paginated saved item tags
+   * @param parent
+   */
+  public getSuggestedBySaveId(parent: PocketSave) {
+    if (!this.context.userIsPremium) {
+      // Suggested Tags is a premium feature.
+      return [];
+    }
+
+    return this.tagService.getSuggestedTags(parent);
   }
 
   /**

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -21,7 +21,7 @@ import {
   upsertSavedItem,
 } from './mutation';
 import { tagsSavedItems } from './tag';
-import { Item, SavedItem, Tag } from '../types';
+import { Item, PocketSave, SavedItem, Tag } from '../types';
 import { IContext } from '../server/context';
 
 const resolvers = {
@@ -31,6 +31,13 @@ const resolvers = {
     },
   },
   User: {
+    pocketSaveById(
+      _parent: any,
+      args: any,
+      context: IContext
+    ): Promise<PocketSave> {
+      return context.models.pocketSave.getById(args.id);
+    },
     savedItemById,
     savedItems,
     tags: userTags,
@@ -51,6 +58,14 @@ const resolvers = {
   CorpusItem: {
     savedItem: async ({ url }, args, context: IContext) => {
       return await context.dataLoaders.savedItemsByUrl.load(url);
+    },
+  },
+  PocketSave: {
+    suggestedTags(parent: PocketSave, _args: any, context: IContext) {
+      return context.models.tag.getSuggestedBySaveId(parent);
+    },
+    tags(parent: PocketSave, _args: any, context: IContext) {
+      return context.models.tag.getBySaveId(parent.id);
     },
   },
   SavedItem: {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -12,6 +12,7 @@ import { createSavedItemDataLoaders } from '../dataLoader/savedItemsDataLoader';
 import { createTagDataLoaders } from '../dataLoader/tagsDataLoader';
 import { TagModel } from '../models';
 import * as Sentry from '@sentry/node';
+import { PocketSaveModel } from '../models/pocketSave';
 
 export interface IContext {
   userId: string;
@@ -22,6 +23,7 @@ export interface IContext {
   eventEmitter: ItemsEventEmitter;
   models: {
     tag: TagModel;
+    pocketSave: PocketSaveModel;
   };
   dataLoaders: {
     savedItemsById: DataLoader<string, SavedItem>;
@@ -55,9 +57,22 @@ export class ContextManager implements IContext {
     };
     this.models = {
       tag: new TagModel(this),
+      pocketSave: new PocketSaveModel(this),
     };
   }
-  models: { tag: TagModel };
+  models: {
+    tag: TagModel;
+    pocketSave: PocketSaveModel;
+  };
+
+  withDbClientOverride(dbClient: Knex): ContextManager {
+    const config = {
+      ...this.config,
+      dbClient,
+    };
+    return new ContextManager(config);
+  }
+
   get headers(): { [key: string]: any } {
     return this.config.request.headers;
   }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -65,14 +65,6 @@ export class ContextManager implements IContext {
     pocketSave: PocketSaveModel;
   };
 
-  withDbClientOverride(dbClient: Knex): ContextManager {
-    const config = {
-      ...this.config,
-      dbClient,
-    };
-    return new ContextManager(config);
-  }
-
   get headers(): { [key: string]: any } {
     return this.config.request.headers;
   }

--- a/src/test/graphql/queries/pocketSave.integration.ts
+++ b/src/test/graphql/queries/pocketSave.integration.ts
@@ -1,0 +1,183 @@
+import { readClient } from '../../../database/client';
+import { ContextManager } from '../../../server/context';
+import { startServer } from '../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+
+describe('getPocketSaveByItemId', () => {
+  const db = readClient();
+  const headers = { userid: '1' };
+  const date1 = new Date('2008-10-21 13:57:01');
+  const date2 = new Date('0000-00-00 00:00:00');
+  const date3 = new Date('2008-10-21 14:00:01');
+  const date4 = new Date('2012-08-13 15:32:05');
+  const date5 = new Date('2008-11-03 08:51:01');
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const GET_POCKET_SAVE = `
+    query getPocketSave($userId: ID!, $itemId: ID!) {
+      _entities(representations: { id: $userId, __typename: "User" }) {
+        ... on User {
+          pocketSaveById(id: $itemId) {
+            archived
+            archivedAt
+            createdAt
+            deletedAt
+            favorite
+            favoritedAt
+            givenUrl
+            id
+            status
+            title
+            updatedAt
+          }
+        }
+      }
+    }
+  `;
+
+  afterAll(async () => {
+    await db.destroy();
+    await server.stop();
+  });
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+    await db('list').truncate();
+    await db('list').insert([
+      {
+        api_id: '012',
+        api_id_updated: '012',
+        favorite: 0,
+        given_url: 'http://www.ideashower.com/',
+        item_id: 55,
+        resolved_id: 55,
+        status: 0,
+        time_added: date1,
+        time_favorited: date2,
+        time_read: date3,
+        time_updated: date4,
+        title: 'the Idea Shower',
+        user_id: 1,
+      },
+      {
+        api_id_updated: 'apiid',
+        api_id: 'apiid',
+        favorite: 1,
+        given_url: 'http://irctc.co.in/',
+        item_id: 987,
+        resolved_id: 987,
+        status: 2,
+        time_added: date5,
+        time_favorited: date2,
+        time_read: date5,
+        time_updated: date5,
+        title: '',
+        user_id: 1,
+      },
+      {
+        api_id_updated: 'apiid',
+        api_id: 'apiid',
+        favorite: 1,
+        given_url: 'http://www.frameip.com/voip/',
+        item_id: 551,
+        resolved_id: 551,
+        time_added: date5,
+        time_favorited: date5,
+        time_read: date5,
+        time_updated: date5,
+        title: 'Tout sur la voip',
+        status: 1,
+        user_id: 1,
+      },
+    ]);
+  });
+
+  it('should return a pocket save with all appropriate fields', async () => {
+    const variables = {
+      userId: '1',
+      itemId: '55',
+    };
+
+    const res = await request(app).post(url).set(headers).send({
+      query: GET_POCKET_SAVE,
+      variables,
+    });
+    expect(res.body.data?._entities[0].pocketSaveById.archived).toBe(false);
+    expect(res.body.data?._entities[0].pocketSaveById.archivedAt).toBe(null);
+    expect(res.body.data?._entities[0].pocketSaveById.createdAt).toBe(
+      date1.toISOString()
+    );
+    expect(res.body.data?._entities[0].pocketSaveById.deletedAt).toBe(null);
+    expect(res.body.data?._entities[0].pocketSaveById.favorite).toBe(false);
+    expect(res.body.data?._entities[0].pocketSaveById.favoritedAt).toBe(null);
+    expect(res.body.data?._entities[0].pocketSaveById.givenUrl).toBe(
+      'http://www.ideashower.com/'
+    );
+    expect(res.body.data?._entities[0].pocketSaveById.id).toBe('55');
+    expect(res.body.data?._entities[0].pocketSaveById.status).toBe('UNREAD');
+    expect(res.body.data?._entities[0].pocketSaveById.title).toBe(
+      'the Idea Shower'
+    );
+    expect(res.body.data?._entities[0].pocketSaveById.updatedAt).toBe(
+      date4.toISOString()
+    );
+  });
+  it('should return null if no item is found for the user', async () => {
+    const variables = {
+      userId: '1',
+      itemId: '10',
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: GET_POCKET_SAVE,
+      variables,
+    });
+    expect(res.body.data?._entities[0].pocketSaveById).toBe(null);
+  });
+  it('should have deletedAt field if item is deleted', async () => {
+    const variables = {
+      userId: '1',
+      itemId: '987',
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: GET_POCKET_SAVE,
+      variables,
+    });
+    expect(res.body.data?._entities[0].pocketSaveById.deletedAt).toBe(
+      date5.toISOString()
+    );
+  });
+  it('should resolve archived properly', async () => {
+    const archivedVars = {
+      userId: '1',
+      itemId: '551',
+    };
+    const nonArchivedVars = {
+      userId: '1',
+      itemId: '55',
+    };
+    const archivedRes = await request(app).post(url).set(headers).send({
+      query: GET_POCKET_SAVE,
+      variables: archivedVars,
+    });
+    const nonArchivedRes = await request(app).post(url).set(headers).send({
+      query: GET_POCKET_SAVE,
+      variables: nonArchivedVars,
+    });
+    expect(archivedRes.body.data?._entities[0].pocketSaveById.archived).toBe(
+      true
+    );
+    expect(archivedRes.body.data?._entities[0].pocketSaveById.archivedAt).toBe(
+      date5.toISOString()
+    );
+    expect(nonArchivedRes.body.data?._entities[0].pocketSaveById.archived).toBe(
+      false
+    );
+    expect(
+      nonArchivedRes.body.data?._entities[0].pocketSaveById.archivedAt
+    ).toBe(null);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -178,3 +178,33 @@ export type DeleteSaveTagResponse = {
   save: SavedItem;
   removed: string[]; // Names
 };
+
+/***
+ * PocketSave Entities (a rework of SavedItem) starts here.
+ ***/
+
+/***
+ * Keeping the arbitrary numbers consistent with PocketSaveStatus enum.
+ ***/
+export enum PocketSaveStatus {
+  UNREAD = 0,
+  ARCHIVED = 1,
+  DELETED = 2,
+  HIDDEN = 3,
+}
+
+export type PocketSave = {
+  archived: boolean;
+  archivedAt: Date | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+  favorite: boolean;
+  favoritedAt: Date | null;
+  givenUrl: string;
+  id: string;
+  status: keyof typeof PocketSaveStatus;
+  suggestedTags?: Tag[];
+  tags?: Tag[];
+  title: string;
+  updatedAt: Date;
+};


### PR DESCRIPTION
## Goal

This PR adds the first pass as a PocketSave entity, which is scheduled to eventually replace SavedItem.

To make the split easier, PocketSave has largely used code separated from SavedItem.

It's also been setup to follow a proposed new pattern where business logic lives in models, data source / database logic lives in dataservice, and resolvers are as dumb as possible.

## I'd love feedback/perspectives on:
- getting date handling for 0000-00-00 00:00:00 was a real pain in the ass, since the value coming from the knex response sometimes would be a Date object returning NaN, other times it would be a string. Probably should move the existing checks into utils, but would appreciate other eyes & thoughts
- this is a new setup, would appreciate feedback on it

## References

Jira ticket:
* https://getpocket.atlassian.net/browse/INFRA-821
