### PR TITLE
fix: expose health check url

### DIFF
--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -39,6 +39,11 @@ export function _startServer() {
   // Initialize routes
   app.use('/queueDelete', queueDeleteRouter);
 
+  // Expose health check url
+  app.get('/.well-known/apollo/server-health', (req, res) => {
+    res.status(200).send('ok');
+  });
+
   // Start BatchDelete queue polling
   new BatchDeleteHandler(new EventEmitter());
 


### PR DESCRIPTION
Expose a health check url so blue-green deployment works. Apollo server removed health check. We can update to do a trivial query but this requires less code update and fits with previous patterns ([annotations-api](https://github.com/Pocket/annotations-api/blob/d45cf157e7191aa04024ab5b47faff5a7c070e43/src/server/index.ts#L42))

[INFRA-842]

[INFRA-842]: https://getpocket.atlassian.net/browse/INFRA-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ