### PR TITLE
feat(corpusItem): adding in savedItem on corpus item

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external"])
+
 scalar Url
 
 """
@@ -80,6 +82,15 @@ input PaginationInput {
   If `last` contains a value, `first` should be null/omitted in the input.
   """
   last: Int
+}
+
+type CorpusItem @key(fields: "url") {
+  url: Url! @external
+
+  """
+  The user's saved item, from the Corpus Item, if the corpus item was saved to the user's saves
+  """
+  savedItem: SavedItem
 }
 
 """
@@ -460,7 +471,7 @@ type SavedItemTagAssociation {
   tagId: ID!
 }
 
-extend type User @key(fields: "id") {
+type User @key(fields: "id") {
   #Note more properties exist here but are defined in another service.
 
   """
@@ -507,7 +518,7 @@ type PendingItem @key(fields: "url") {
   status: PendingItemStatus
 }
 
-extend type Item @key(fields: "givenUrl") {
+type Item @key(fields: "givenUrl") {
   "key field to identify the Item entity in the Parser service"
   givenUrl: Url! @external
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,3 @@
-extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external"])
-
 scalar Url
 
 """
@@ -84,7 +82,7 @@ input PaginationInput {
   last: Int
 }
 
-type CorpusItem @key(fields: "url") {
+extend type CorpusItem @key(fields: "url") {
   url: Url! @external
 
   """
@@ -471,7 +469,7 @@ type SavedItemTagAssociation {
   tagId: ID!
 }
 
-type User @key(fields: "id") {
+extend type User @key(fields: "id") {
   #Note more properties exist here but are defined in another service.
 
   """
@@ -518,7 +516,7 @@ type PendingItem @key(fields: "url") {
   status: PendingItemStatus
 }
 
-type Item @key(fields: "givenUrl") {
+extend type Item @key(fields: "givenUrl") {
   "key field to identify the Item entity in the Parser service"
   givenUrl: Url! @external
 
@@ -603,9 +601,7 @@ type Mutation {
   Note that if this operation results in a Tag having no associations
   to a SavedItem, the Tag object will be deleted.
   """
-  deleteSavedItemTags(
-    input: [DeleteSavedItemTagsInput!]!
-  ): [SavedItem!]!
+  deleteSavedItemTags(input: [DeleteSavedItemTagsInput!]!): [SavedItem!]!
 
   """
   Add tags to the savedItems

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -24,7 +24,6 @@ import { tagsSavedItems } from './tag';
 import { Item, SavedItem, Tag } from '../types';
 import { IContext } from '../server/context';
 import { writeClient } from '../database/client';
-import { NotFoundError } from '@pocket-tools/apollo-utils';
 
 const resolvers = {
   ItemResult: {
@@ -39,13 +38,7 @@ const resolvers = {
   },
   Item: {
     savedItem: async (item: Item, args, context: IContext) => {
-      const save = await context.dataLoaders.savedItemsByUrl.load(
-        item.givenUrl
-      );
-      if (save == null) {
-        throw new NotFoundError(`No Save found for url=${item.givenUrl}`);
-      }
-      return save;
+      return await context.dataLoaders.savedItemsByUrl.load(item.givenUrl);
     },
     // This is basically a passthrough so that the givenUrl is available
     // on the parent when the savedItem entity is resolved
@@ -54,6 +47,11 @@ const resolvers = {
     // If other scalar fields were resolved by list on Item, they'd go here
     __resolveReference: async (item: Item, context: IContext) => {
       return item;
+    },
+  },
+  CorpusItem: {
+    savedItem: async ({ url }, args, context: IContext) => {
+      return await context.dataLoaders.savedItemsByUrl.load(url);
     },
   },
   SavedItem: {

--- a/src/test/graphql/queries/curatedItem.integration.ts
+++ b/src/test/graphql/queries/curatedItem.integration.ts
@@ -1,0 +1,128 @@
+import { readClient } from '../../../database/client';
+import chai, { expect } from 'chai';
+import chaiDateTime from 'chai-datetime';
+import deepEqualInAnyOrder from 'deep-equal-in-any-order';
+import { ContextManager } from '../../../server/context';
+import { startServer } from '../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+
+chai.use(chaiDateTime);
+chai.use(deepEqualInAnyOrder);
+
+describe('getSavedItemsOnCuratedItem', () => {
+  const db = readClient();
+  const headers = { userid: '1' };
+
+  // TODO: What date is the server running in? Web repo does central...
+  // should this do UTC, this changes pagination cursors.
+  const date1 = new Date('2020-10-03 10:20:30'); // Consistent date for seeding
+  const date2 = new Date('2020-10-03 10:22:30'); // Consistent date for seeding
+  const date3 = new Date('2020-10-03 10:25:30'); // Consistent date for seeding
+  const nullDate = new Date('0000-00-00 00:00:00');
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  beforeAll(async () => ({ app, server, url } = await startServer(0)));
+
+  afterAll(async () => {
+    await db.destroy();
+    await server.stop();
+  });
+
+  beforeEach(async () => {
+    await db('list').truncate();
+    await db('list').insert([
+      {
+        user_id: 1,
+        item_id: 1,
+        resolved_id: 1,
+        given_url: 'http://abc',
+        title: 'mytitle',
+        time_added: date1,
+        time_updated: date2,
+        time_read: date1,
+        time_favorited: nullDate,
+        api_id: 'apiid',
+        status: 1,
+        favorite: 0,
+        api_id_updated: 'apiid',
+      },
+      {
+        user_id: 1,
+        item_id: 2,
+        resolved_id: 2,
+        given_url: 'http://def',
+        title: 'title2',
+        time_added: date2,
+        time_updated: date3,
+        time_read: date2,
+        time_favorited: date2,
+        api_id: 'apiid',
+        status: 0,
+        favorite: 1,
+        api_id_updated: 'apiid',
+      },
+      {
+        user_id: 1,
+        item_id: 3,
+        resolved_id: 1,
+        given_url: 'http://ijk',
+        title: 'mytitle',
+        time_added: date3,
+        time_updated: date1,
+        time_read: date3,
+        time_favorited: date1,
+        api_id: 'apiid',
+        status: 0,
+        favorite: 1,
+        api_id_updated: 'apiid',
+      },
+    ]);
+  });
+
+  it('can resolve a entity query for a SavedItem by Url on Corpus Item', async () => {
+    const RESOLVE_REFERENCE_QUERY = `
+      query ($_representations: [_Any!]!) {
+        _entities(representations: $_representations) {
+          ... on CorpusItem {
+            savedItem {
+              url
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const variables = {
+      _representations: [
+        {
+          __typename: 'CorpusItem',
+          url: 'http://abc',
+        },
+        {
+          __typename: 'CorpusItem',
+          url: 'http://def',
+        },
+        {
+          __typename: 'CorpusItem',
+          url: 'http://blah',
+        },
+      ],
+    };
+
+    const res = await request(app).post(url).set(headers).send({
+      query: RESOLVE_REFERENCE_QUERY,
+      variables,
+    });
+
+    expect(res.body.data._entities[0].savedItem.url).to.equal('http://abc');
+    expect(res.body.data._entities[0].savedItem.id).to.equal('1');
+    expect(res.body.data._entities[1].savedItem.url).to.equal('http://def');
+    expect(res.body.data._entities[1].savedItem.id).to.equal('2');
+    expect(res.body.data._entities[2].savedItem).to.be.null;
+  });
+});

--- a/src/test/graphql/queries/item.integration.ts
+++ b/src/test/graphql/queries/item.integration.ts
@@ -173,7 +173,7 @@ describe('item', () => {
     expect(entities.length).toEqual(1);
     expect(entities[0]).toEqual(expected);
   });
-  it('returns null with not found error if the save does not exist', async () => {
+  it('returns null if the save does not exist', async () => {
     const variables = {
       userId: '1',
       givenUrl: 'https://www.youtube.com/watch?v=Tpbo25iBvfU',
@@ -184,9 +184,7 @@ describe('item', () => {
       variables,
     });
     expect(res.body.data).not.toBeUndefined;
-    expect(res.body.errors).not.toBeUndefined;
-    expect(res.body.errors.length).toEqual(1);
-    expect(res.body.errors[0].extensions.code).toEqual('NOT_FOUND');
+    expect(res.body.errors).toBeUndefined;
     const entities = res.body.data._entities;
     expect(entities.length).toEqual(1);
     expect(entities[0].givenUrl).toEqual(


### PR DESCRIPTION
## Goal

Clients need to know if a Corpus Item has been saved to a user's saves for display purposes. (ie. should they display a saved button on recomendations)