### PR TITLE
Updating schema for bulk mutation responses

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -506,7 +506,7 @@ extend type User @key(fields: "id") {
   """
   Get a PocketSave by its id
   """
-  pocketSaveById(id: ID!): PocketSave
+  saveById(id: ID!): PocketSave
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,6 +7,22 @@ scalar ISOString
 
 scalar Url
 
+type SyncConflict implements BaseError {
+  path: String!
+  message: String!
+}
+
+type NotFound implements BaseError {
+  path: String!
+  message: String!
+}
+
+interface BaseError {
+  path: String!
+  message: String! 
+}
+
+
 """
 Interface that all state based entities must implement
 """
@@ -514,6 +530,12 @@ Union type for items that may or may not be processed
 """
 union ItemResult = PendingItem | Item
 
+"""All types in this union should implement BaseError, for client fallback"""
+union TagMutationError = NotFound | SyncConflict # hypothetically others in the future...
+
+"""All types in this union should implement BaseError, for client fallback"""
+union SaveMutationError = NotFound | SyncConflict # hypothetically others in the future
+
 enum PendingItemStatus {
   RESOLVED
   UNRESOLVED
@@ -764,6 +786,57 @@ type PocketSave {
   updatedAt: ISOString
 }
 
+
+"""
+Payload for mutations that create or update Saves
+"""
+type SaveWriteMutationPayload {
+  """
+  The mutated Save objects; empty if the mutation did not succeed.
+  """
+  save: [PocketSave!]!
+  """
+  Any errors associated with the mutation. Empty if the mutation was succesful.
+  """
+  errors: [SaveMutationError!]!
+}
+
+"""
+Payload for mutations that delete Saves
+"""
+type SaveDeleteMutationPayload {
+  success: Boolean!
+  """
+  Any errors associated with the mutation. Empty if the mutation was succesful.
+  """
+  errors: [SaveMutationError!]!
+}
+
+
+"""
+Payload for mutations that create or update Tags
+"""
+type TagWriteMutationPayload {
+  """
+  The mutated Tag objects; empty if the mutation did not succeed.
+  """
+  tag: [Tag!]!
+  """
+  Any errors associated with the mutation. Empty if the mutation was succesful.
+  """
+  errors: [TagMutationError!]!
+}
+
+"""
+Payload for mutations that delete Tags
+"""
+type TagDeleteMutationPayload {
+  success: Boolean!
+  """
+  Any errors associated with the mutation. Empty if the mutation was succesful.
+  """
+  errors: [TagMutationError!]!
+}
 # To be setup: connect PocketSaves to a new entity - PocketResource
 # extend type PocketResource @key(fields: "itemId") {
 #   "key field to identify the PocketResource entity in the Parser service"

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -31,11 +31,7 @@ const resolvers = {
     },
   },
   User: {
-    pocketSaveById(
-      _parent: any,
-      args: any,
-      context: IContext
-    ): Promise<PocketSave> {
+    saveById(_parent: any, args: any, context: IContext): Promise<PocketSave> {
       return context.models.pocketSave.getById(args.id);
     },
     savedItemById,

--- a/src/test/graphql/queries/pocketSave.integration.ts
+++ b/src/test/graphql/queries/pocketSave.integration.ts
@@ -23,7 +23,7 @@ describe('getPocketSaveByItemId', () => {
     query getPocketSave($userId: ID!, $itemId: ID!) {
       _entities(representations: { id: $userId, __typename: "User" }) {
         ... on User {
-          pocketSaveById(id: $itemId) {
+          saveById(id: $itemId) {
             archived
             archivedAt
             createdAt
@@ -111,23 +111,21 @@ describe('getPocketSaveByItemId', () => {
         query: print(GET_POCKET_SAVE),
         variables,
       });
-    expect(res.body.data?._entities[0].pocketSaveById.archived).toBe(false);
-    expect(res.body.data?._entities[0].pocketSaveById.archivedAt).toBe(null);
-    expect(res.body.data?._entities[0].pocketSaveById.createdAt).toBe(
+    expect(res.body.data?._entities[0].saveById.archived).toBe(false);
+    expect(res.body.data?._entities[0].saveById.archivedAt).toBe(null);
+    expect(res.body.data?._entities[0].saveById.createdAt).toBe(
       date1.toISOString()
     );
-    expect(res.body.data?._entities[0].pocketSaveById.deletedAt).toBe(null);
-    expect(res.body.data?._entities[0].pocketSaveById.favorite).toBe(false);
-    expect(res.body.data?._entities[0].pocketSaveById.favoritedAt).toBe(null);
-    expect(res.body.data?._entities[0].pocketSaveById.givenUrl).toBe(
+    expect(res.body.data?._entities[0].saveById.deletedAt).toBe(null);
+    expect(res.body.data?._entities[0].saveById.favorite).toBe(false);
+    expect(res.body.data?._entities[0].saveById.favoritedAt).toBe(null);
+    expect(res.body.data?._entities[0].saveById.givenUrl).toBe(
       'http://www.ideashower.com/'
     );
-    expect(res.body.data?._entities[0].pocketSaveById.id).toBe('55');
-    expect(res.body.data?._entities[0].pocketSaveById.status).toBe('UNREAD');
-    expect(res.body.data?._entities[0].pocketSaveById.title).toBe(
-      'the Idea Shower'
-    );
-    expect(res.body.data?._entities[0].pocketSaveById.updatedAt).toBe(
+    expect(res.body.data?._entities[0].saveById.id).toBe('55');
+    expect(res.body.data?._entities[0].saveById.status).toBe('UNREAD');
+    expect(res.body.data?._entities[0].saveById.title).toBe('the Idea Shower');
+    expect(res.body.data?._entities[0].saveById.updatedAt).toBe(
       date4.toISOString()
     );
   });
@@ -143,7 +141,7 @@ describe('getPocketSaveByItemId', () => {
         query: print(GET_POCKET_SAVE),
         variables,
       });
-    expect(res.body.data?._entities[0].pocketSaveById).toBe(null);
+    expect(res.body.data?._entities[0].saveById).toBe(null);
     expect(res.body.errors[0].message).toBe(
       `Error - Not Found: Saved Item with ID=${variables.itemId} does not exist.`
     );
@@ -161,7 +159,7 @@ describe('getPocketSaveByItemId', () => {
         query: print(GET_POCKET_SAVE),
         variables,
       });
-    expect(res.body.data?._entities[0].pocketSaveById.deletedAt).toBe(
+    expect(res.body.data?._entities[0].saveById.deletedAt).toBe(
       date5.toISOString()
     );
   });
@@ -188,17 +186,15 @@ describe('getPocketSaveByItemId', () => {
         query: print(GET_POCKET_SAVE),
         variables: nonArchivedVars,
       });
-    expect(archivedRes.body.data?._entities[0].pocketSaveById.archived).toBe(
-      true
-    );
-    expect(archivedRes.body.data?._entities[0].pocketSaveById.archivedAt).toBe(
+    expect(archivedRes.body.data?._entities[0].saveById.archived).toBe(true);
+    expect(archivedRes.body.data?._entities[0].saveById.archivedAt).toBe(
       date5.toISOString()
     );
-    expect(nonArchivedRes.body.data?._entities[0].pocketSaveById.archived).toBe(
+    expect(nonArchivedRes.body.data?._entities[0].saveById.archived).toBe(
       false
     );
-    expect(
-      nonArchivedRes.body.data?._entities[0].pocketSaveById.archivedAt
-    ).toBe(null);
+    expect(nonArchivedRes.body.data?._entities[0].saveById.archivedAt).toBe(
+      null
+    );
   });
 });


### PR DESCRIPTION
## Goal

Adding the bulk mutation responses from the accepted proposal so that implementing tickets don't have to deal with mege conflicts.

Also includes a fix to `pocketSaveById -> saveById` to comply with accepted proposal.

[INFRA-811]

[INFRA-811]: https://getpocket.atlassian.net/browse/INFRA-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ