### PR TITLE
feat(validation): Prototyping input validation with @constraint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: install rover
           command: |
             # download and install Rover
-            curl -sSL https://rover.apollo.dev/nix/v0.1.0 | sh
+            curl -sSL https://rover.apollo.dev/nix/v0.11.1 | sh
 
             # This allows the PATH changes to persist to the next `run` step
             echo 'export PATH=$HOME/.rover/bin:$PATH' >> $BASH_ENV

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@apollo/server": "4.3.0",
         "@apollo/server-plugin-landing-page-graphql-playground": "4.0.0",
-        "@apollo/subgraph": "2.0.5",
+        "@apollo/subgraph": "2.3.2",
         "@aws-sdk/client-eventbridge": "3.92.0",
         "@aws-sdk/client-kinesis": "3.53.0",
         "@aws-sdk/client-sqs": "3.53.0",
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.2.2.tgz",
-      "integrity": "sha512-Q16I75qZ6jA8lCoZedM5938oZONrJyL7Pk6TOqw44fndea0As0pb2Ug8dV3pAWq4HhJ+/vBu2WoP14CFcxA9Yw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.3.2.tgz",
+      "integrity": "sha512-XtXQag8sV75BoNlzu6ci5mn2U+QGNZdkRB8Igi5e31VqnBx4XSdvbyx6Ht1lvYru9GCYx6OqGWZqqPqAXG72/Q==",
       "dependencies": {
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
@@ -313,17 +313,18 @@
       }
     },
     "node_modules/@apollo/subgraph": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.0.5.tgz",
-      "integrity": "sha512-bnxxoYmlalYJ5wiE2iOYae6bc9fHKik0zOHGcfTLpIm/T3l+1J0Gj5QIVYOs7u/agduo3VGjm8MQbvrtNHJExg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.3.2.tgz",
+      "integrity": "sha512-PYSVD+tx49EVjII25Ip1QsrOCn/Bmh7KBqoqZsp/AT/8yGbqX5j9oAeRH37QcOxbl8TXBcJBDKbPO/KzUln1Dg==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.0.5"
+        "@apollo/cache-control-types": "^1.0.2",
+        "@apollo/federation-internals": "2.3.2"
       },
       "engines": {
-        "node": ">=12.13.0 <18.0"
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
-        "graphql": "^16.0.0"
+        "graphql": "^16.5.0"
       }
     },
     "node_modules/@apollo/usage-reporting-protobuf": {
@@ -5547,21 +5548,6 @@
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "md5": "^2.3.0"
-      }
-    },
-    "node_modules/@pocket-tools/apollo-utils/node_modules/@apollo/subgraph": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.2.2.tgz",
-      "integrity": "sha512-CUJPN1v9JZgkMBWkmufJMGduUwTD4fFyjOk2oLRWUDB41r9+eeyI3/CvuuGaZH+xMxMOSf5HN9tbbAO/sPnuTQ==",
-      "dependencies": {
-        "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/federation-internals": "^2.2.2"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "graphql": "^16.5.0"
       }
     },
     "node_modules/@pocket-tools/apollo-utils/node_modules/@sentry/core": {
@@ -14999,9 +14985,9 @@
       "requires": {}
     },
     "@apollo/federation-internals": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.2.2.tgz",
-      "integrity": "sha512-Q16I75qZ6jA8lCoZedM5938oZONrJyL7Pk6TOqw44fndea0As0pb2Ug8dV3pAWq4HhJ+/vBu2WoP14CFcxA9Yw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.3.2.tgz",
+      "integrity": "sha512-XtXQag8sV75BoNlzu6ci5mn2U+QGNZdkRB8Igi5e31VqnBx4XSdvbyx6Ht1lvYru9GCYx6OqGWZqqPqAXG72/Q==",
       "requires": {
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
@@ -15152,11 +15138,12 @@
       }
     },
     "@apollo/subgraph": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.0.5.tgz",
-      "integrity": "sha512-bnxxoYmlalYJ5wiE2iOYae6bc9fHKik0zOHGcfTLpIm/T3l+1J0Gj5QIVYOs7u/agduo3VGjm8MQbvrtNHJExg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.3.2.tgz",
+      "integrity": "sha512-PYSVD+tx49EVjII25Ip1QsrOCn/Bmh7KBqoqZsp/AT/8yGbqX5j9oAeRH37QcOxbl8TXBcJBDKbPO/KzUln1Dg==",
       "requires": {
-        "@apollo/federation-internals": "^2.0.5"
+        "@apollo/cache-control-types": "^1.0.2",
+        "@apollo/federation-internals": "2.3.2"
       }
     },
     "@apollo/usage-reporting-protobuf": {
@@ -19229,15 +19216,6 @@
         "md5": "^2.3.0"
       },
       "dependencies": {
-        "@apollo/subgraph": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.2.2.tgz",
-          "integrity": "sha512-CUJPN1v9JZgkMBWkmufJMGduUwTD4fFyjOk2oLRWUDB41r9+eeyI3/CvuuGaZH+xMxMOSf5HN9tbbAO/sPnuTQ==",
-          "requires": {
-            "@apollo/cache-control-types": "^1.0.2",
-            "@apollo/federation-internals": "^2.2.2"
-          }
-        },
         "@sentry/core": {
           "version": "7.26.0",
           "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.26.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,10 +31,11 @@
         "dataloader": "2.0.0",
         "express": "4.18.2",
         "express-validator": "6.14.3",
+        "graphql-constraint-directive": "5.0.0",
         "graphql-depth-limit": "1.1.0",
-        "knex": "0.95.15",
+        "knex": "^2.4.2",
         "locutus": "2.0.16",
-        "luxon": "2.3.2",
+        "luxon": "^2.5.2",
         "mysql": "2.18.1",
         "nanoid": "3.3.4"
       },
@@ -6821,9 +6822,9 @@
       }
     },
     "node_modules/@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
@@ -8520,9 +8521,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colorette": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -8536,11 +8537,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "engines": {
-        "node": ">= 10"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/component-emitter": {
@@ -8612,9 +8613,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "node_modules/core-util-is": {
@@ -9851,9 +9852,9 @@
       }
     },
     "node_modules/getopts": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
-      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -9958,6 +9959,22 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/graphql-constraint-directive": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-constraint-directive/-/graphql-constraint-directive-5.0.0.tgz",
+      "integrity": "sha512-fyLXout1VM8dpNlcwmrsTPvkJsCjKJU9HnddZAeUENr8IptLF8+V5f9Dzitco+VXKfdoooMKrjIp7//Obk841Q==",
+      "dependencies": {
+        "@graphql-tools/schema": "^9.0.0",
+        "@graphql-tools/utils": "^9.0.0",
+        "validator": "^13.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "graphql": ">=14.0.0"
+      }
+    },
     "node_modules/graphql-depth-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
@@ -10059,9 +10076,9 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -12169,9 +12186,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -12203,31 +12220,35 @@
       }
     },
     "node_modules/knex": {
-      "version": "0.95.15",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.15.tgz",
-      "integrity": "sha512-Loq6WgHaWlmL2bfZGWPsy4l8xw4pOE+tmLGkPG0auBppxpI0UcK+GYCycJcqz9W54f2LiGewkCVLBm3Wq4ur/w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.2.tgz",
+      "integrity": "sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==",
       "dependencies": {
-        "colorette": "2.0.16",
-        "commander": "^7.1.0",
-        "debug": "4.3.2",
+        "colorette": "2.0.19",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
-        "getopts": "2.2.5",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
         "pg-connection-string": "2.5.0",
-        "rechoir": "0.7.0",
+        "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
-        "tarn": "^3.0.1",
+        "tarn": "^3.0.2",
         "tildify": "2.0.0"
       },
       "bin": {
         "knex": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
         "mysql": {
           "optional": true
         },
@@ -12244,22 +12265,6 @@
           "optional": true
         },
         "tedious": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/knex/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
           "optional": true
         }
       }
@@ -12419,9 +12424,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.2.tgz",
-      "integrity": "sha512-MlAQQVMFhGk4WUA6gpfsy0QycnKP0+NlCBJRVRNPxxSIbjrCbQ65nrpJD3FVyJNZLuJ0uoqL57ye6BmDYgHaSw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
+      "integrity": "sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA==",
       "engines": {
         "node": ">=12"
       }
@@ -13513,14 +13518,14 @@
       }
     },
     "node_modules/rechoir": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dependencies": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/redis-commands": {
@@ -20226,9 +20231,9 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",
@@ -21598,9 +21603,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colorette": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -21611,9 +21616,9 @@
       }
     },
     "commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -21674,9 +21679,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "core-util-is": {
@@ -22615,9 +22620,9 @@
       }
     },
     "getopts": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
-      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
     },
     "glob": {
       "version": "7.2.3",
@@ -22692,6 +22697,16 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
+    "graphql-constraint-directive": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-constraint-directive/-/graphql-constraint-directive-5.0.0.tgz",
+      "integrity": "sha512-fyLXout1VM8dpNlcwmrsTPvkJsCjKJU9HnddZAeUENr8IptLF8+V5f9Dzitco+VXKfdoooMKrjIp7//Obk841Q==",
+      "requires": {
+        "@graphql-tools/schema": "^9.0.0",
+        "@graphql-tools/utils": "^9.0.0",
+        "validator": "^13.6.0"
+      }
+    },
     "graphql-depth-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
@@ -22757,9 +22772,9 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -24398,9 +24413,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "just-extend": {
       "version": "4.2.1",
@@ -24423,33 +24438,26 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "knex": {
-      "version": "0.95.15",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.15.tgz",
-      "integrity": "sha512-Loq6WgHaWlmL2bfZGWPsy4l8xw4pOE+tmLGkPG0auBppxpI0UcK+GYCycJcqz9W54f2LiGewkCVLBm3Wq4ur/w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.2.tgz",
+      "integrity": "sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==",
       "requires": {
-        "colorette": "2.0.16",
-        "commander": "^7.1.0",
-        "debug": "4.3.2",
+        "colorette": "2.0.19",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
-        "getopts": "2.2.5",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
         "pg-connection-string": "2.5.0",
-        "rechoir": "0.7.0",
+        "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
-        "tarn": "^3.0.1",
+        "tarn": "^3.0.2",
         "tildify": "2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -24579,9 +24587,9 @@
       }
     },
     "luxon": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.2.tgz",
-      "integrity": "sha512-MlAQQVMFhGk4WUA6gpfsy0QycnKP0+NlCBJRVRNPxxSIbjrCbQ65nrpJD3FVyJNZLuJ0uoqL57ye6BmDYgHaSw=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
+      "integrity": "sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -25355,11 +25363,11 @@
       }
     },
     "rechoir": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "requires": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       }
     },
     "redis-commands": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/server": "4.3.0",
     "@apollo/server-plugin-landing-page-graphql-playground": "4.0.0",
-    "@apollo/subgraph": "2.0.5",
+    "@apollo/subgraph": "2.3.2",
     "@aws-sdk/client-eventbridge": "3.92.0",
     "@aws-sdk/client-kinesis": "3.53.0",
     "@aws-sdk/client-sqs": "3.53.0",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
     "dataloader": "2.0.0",
     "express": "4.18.2",
     "express-validator": "6.14.3",
+    "graphql-constraint-directive": "5.0.0",
     "graphql-depth-limit": "1.1.0",
-    "knex": "0.95.15",
+    "knex": "^2.4.2",
     "locutus": "2.0.16",
-    "luxon": "2.3.2",
+    "luxon": "^2.5.2",
     "mysql": "2.18.1",
     "nanoid": "3.3.4"
   },

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,6 @@
 extend schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.1",
         import: ["@key", "@composeDirective"])
   # The link directive is required to federate @constraint
   # It doesn't actually have to be a real spec, but it would be good

--- a/schema.graphql
+++ b/schema.graphql
@@ -2,6 +2,10 @@ extend schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/federation/v2.0",
         import: ["@key"])
+  # The link directive is required to federate @constraint
+  # It doesn't actually have to be a real spec, but it would be good
+  # to write one and replace this.
+  @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@constraint"])
   @composeDirective(name:"@constraint")
 
 directive @composeDirective(name: String!) repeatable on SCHEMA

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,14 +1,12 @@
 extend schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
-        import: ["@key"])
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@composeDirective"])
   # The link directive is required to federate @constraint
   # It doesn't actually have to be a real spec, but it would be good
   # to write one and replace this.
   @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@constraint"])
   @composeDirective(name:"@constraint")
-
-directive @composeDirective(name: String!) repeatable on SCHEMA
 
 """
 ISOString scalar - all datetimes fields are Typescript Date objects on this server &

--- a/schema.graphql
+++ b/schema.graphql
@@ -514,6 +514,12 @@ Union type for items that may or may not be processed
 """
 union ItemResult = PendingItem | Item
 
+
+input BulkMutationInput {
+  bulkInputs: [String!]! @constraint(minItems: 1, maxItems: 30)
+  timestamp: ISOString!
+}
+
 enum PendingItemStatus {
   RESOLVED
   UNRESOLVED
@@ -631,6 +637,8 @@ type Mutation {
   Returns the SavedItem for which the tags have been modified.
   """
   replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
+
+  fakeBulkMutation(input: BulkMutationInput!): Boolean!
 }
 
 # """

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
+
 """
 ISOString scalar - all datetimes fields are Typescript Date objects on this server &
 returned as ISO-8601 encoded date strings (e.g. ISOString scalars) to GraphQL clients.
@@ -516,7 +518,7 @@ union ItemResult = PendingItem | Item
 
 
 input BulkMutationInput {
-  bulkInputs: [String!]! @constraint(minItems: 1, maxItems: 30)
+  bulkInputs: [Int!]! @constraint(minItems: 1, maxItems: 30)
   timestamp: ISOString!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,10 @@
-extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
+extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/federation/v2.0",
+        import: ["@key"])
+  @composeDirective(name:"@constraint")
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
 
 """
 ISOString scalar - all datetimes fields are Typescript Date objects on this server &
@@ -91,8 +97,8 @@ input PaginationInput {
   last: Int
 }
 
-extend type CorpusItem @key(fields: "url") {
-  url: Url! @external
+type CorpusItem @key(fields: "url") {
+  url: Url!
 
   """
   The user's saved item, from the Corpus Item, if the corpus item was saved to the user's saves
@@ -478,13 +484,13 @@ type SavedItemTagAssociation {
   tagId: ID!
 }
 
-extend type User @key(fields: "id") {
+type User @key(fields: "id") {
   #Note more properties exist here but are defined in another service.
 
   """
   User id, provided by the user service.
   """
-  id: ID! @external
+  id: ID
 
   """
   Get a general paginated listing of all SavedItems for the user
@@ -536,9 +542,9 @@ type PendingItem @key(fields: "url") {
   status: PendingItemStatus
 }
 
-extend type Item @key(fields: "givenUrl") {
+type Item @key(fields: "givenUrl") {
   "key field to identify the Item entity in the Parser service"
-  givenUrl: Url! @external
+  givenUrl: Url! 
 
   #Note more properties exist here but are defined in another service.
 
@@ -775,9 +781,9 @@ type PocketSave {
 }
 
 # To be setup: connect PocketSaves to a new entity - PocketResource
-# extend type PocketResource @key(fields: "itemId") {
+# type PocketResource @key(fields: "itemId") {
 #   "key field to identify the PocketResource entity in the Parser service"
-#   itemId: ID! @external
+#   itemId: ID!
 
 #   """
 #   Identify if the given PocketResource is in the user's list.

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -103,6 +103,7 @@ const resolvers = {
     deleteTag,
     createSavedItemTags,
     replaceSavedItemTags,
+    fakeBulkMutation: () => true,
   },
 };
 

--- a/src/test/graphql/mutations/fakeBulkMutation.integration.ts
+++ b/src/test/graphql/mutations/fakeBulkMutation.integration.ts
@@ -1,0 +1,38 @@
+import { startServer } from '../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import { ContextManager } from '../../../server/context';
+import request from 'supertest';
+
+describe('fake bulk mutation', () => {
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+  const headers = { userid: '1' };
+
+  const fakeBulkMutation = `
+  mutation fakeBulkMutation($input: BulkMutationInput!) {
+    updateTag(input: $input)
+  }
+`;
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+  it('disallows empty array inputs', async () => {
+    const variables = {
+      input: { bulkInputs: [], timestamp: '10-06-2023' },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: fakeBulkMutation,
+      variables,
+    });
+    expect(res.body.errors.length).toEqual(1);
+  });
+  it.todo('disallows array size > 30');
+  it.todo('works for array size greater than 0 and less than 30');
+});

--- a/src/test/graphql/mutations/fakeBulkMutation.integration.ts
+++ b/src/test/graphql/mutations/fakeBulkMutation.integration.ts
@@ -12,7 +12,7 @@ describe('fake bulk mutation', () => {
 
   const fakeBulkMutation = `
   mutation fakeBulkMutation($input: BulkMutationInput!) {
-    updateTag(input: $input)
+    fakeBulkMutation(input: $input)
   }
 `;
 
@@ -32,7 +32,37 @@ describe('fake bulk mutation', () => {
       variables,
     });
     expect(res.body.errors.length).toEqual(1);
+    expect(res.body.errors[0].extensions.code).toEqual('BAD_USER_INPUT');
+    expect(res.body.errors[0].message).toContain(
+      'must be at least 1 in length'
+    );
   });
-  it.todo('disallows array size > 30');
-  it.todo('works for array size greater than 0 and less than 30');
+  it('disallows array size > 30', async () => {
+    const variables = {
+      input: {
+        bulkInputs: Array.from(Array(100).keys()),
+        timestamp: '10-06-2023',
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: fakeBulkMutation,
+      variables,
+    });
+    expect(res.body.errors[0].extensions.code).toEqual('BAD_USER_INPUT');
+    expect(res.body.errors[0].message).toContain('must be no more than 30');
+  });
+  it('works for array size greater than 0 and less than 30', async () => {
+    const variables = {
+      input: {
+        bulkInputs: Array.from(Array(10).keys()),
+        timestamp: '10-06-2023',
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: fakeBulkMutation,
+      variables,
+    });
+    expect(res.body.errors).toBeUndefined;
+    expect(res.body.data.fakeBulkMutation).toEqual(true);
+  });
 });


### PR DESCRIPTION
## Goal
Literally as I was looking at [graphql-constraint-directive](https://github.com/confuser/graphql-constraint-directive) and remembering why I couldn't test it out before, the maintainer merged a fix for it to work with apollo v4. Is it fate?

Note: I contributed a small typescript fix to the library which has been merged but not yet released -- that's what those TODOs are about. I'll also need to do a little more finangling to get this to build in the studio, but it works locally.

I think this is a nice way to go. It's self-documenting and testable. The only thing that we have to consider is that it can't be applied on the arguments, so we'll have to add input types for all the bulk mutations. This would technically be a change to the contract but I don't think it would be problematic. I think the only other viable alternative would be putting it directly in the resolver/model code, as writing our own plugin would be an unnecessary maintenance burden when graphql-constraint-directive already exists.

e.g. instead of 
```
tagRename(input: [TagRenameInput!]!, timestamp: ISOString!): TagWriteMutationPayload!
```

we'd need something like

```
input BulkTagRenameInput {
  inputs: [TagRenameInput!]! @constraint(minItems: 1, maxItems: 30)
  timestamp: ISOString!
}

tagRename(input: BulkTagRenameInput): TagWriteMutationPayload!
```

[INFRA-549]


[INFRA-549]: https://getpocket.atlassian.net/browse/INFRA-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ