### PR TITLE
feat(isostring): use isostring custom scalar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5046,6 +5046,41 @@
         "@types/serve-static": "*"
       }
     },
+<<<<<<< HEAD
+=======
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.6.0.tgz",
+      "integrity": "sha512-TBnEW1wthnfcYA65VJqbFtDpKqDnwTqqJ9R1tQ4qU3qrxhRhN6mMOok6XaCbT+ddCerI7fvWHtm5jYBJ00XQmw==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "dependencies": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+>>>>>>> c182506 (bug(xray): replace node-autoinstr w/specific pkgs to unblock apollo-utils update)
     "node_modules/@opentelemetry/instrumentation-graphql": {
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.1.tgz",
@@ -24651,6 +24686,31 @@
             "@types/serve-static": "*"
           }
         }
+<<<<<<< HEAD
+=======
+      }
+    },
+    "@opentelemetry/instrumentation-fs": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.6.0.tgz",
+      "integrity": "sha512-TBnEW1wthnfcYA65VJqbFtDpKqDnwTqqJ9R1tQ4qU3qrxhRhN6mMOok6XaCbT+ddCerI7fvWHtm5jYBJ00XQmw==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "dependencies": {
+        "@opentelemetry/instrumentation": {
+          "version": "0.34.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+          "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+          "requires": {
+            "require-in-the-middle": "^5.0.3",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
+          }
+        }
+>>>>>>> c182506 (bug(xray): replace node-autoinstr w/specific pkgs to unblock apollo-utils update)
       }
     },
     "@opentelemetry/instrumentation-graphql": {

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -23,8 +23,10 @@ import {
 import { tagsSavedItems } from './tag';
 import { Item, PocketSave, SavedItem, Tag } from '../types';
 import { IContext } from '../server/context';
+import { PocketDefaultScalars } from '@pocket-tools/apollo-utils';
 
 const resolvers = {
+  ...PocketDefaultScalars,
   ItemResult: {
     __resolveType(savedItem: SavedItem) {
       return parseInt(savedItem.resolvedId) ? 'Item' : 'PendingItem';


### PR DESCRIPTION
~blocked by #643~

## Goal
Update ISOString type to actually point to the custom scalar definition from apollo-utils package.

## I'd love feedback/perspectives on:
- should I add more date tests here as well?

## Implementation Decisions
- mostly upstream

## References

Jira ticket:
* https://getpocket.atlassian.net/browse/INFRA-812
