### PR TITLE
feat(PendingItem): add itemId to pending item

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -542,7 +542,7 @@ type PendingItem @key(fields: "url") {
   URL of the item that the user gave for the SavedItem
   that is pending processing by parser
   """
-  itemId: ID!
+  itemId: String!
   url: Url!
   status: PendingItemStatus
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -58,7 +58,7 @@ interface RemoteEntity {
 """
 Information about pagination in a connection.
 """
-type PageInfo {
+type PageInfo @shareable {
   """
   When paginating forwards, the cursor to continue.
   """
@@ -550,7 +550,7 @@ type PendingItem @key(fields: "url") {
 type Item @key(fields: "givenUrl") {
   "key field to identify the Item entity in the Parser service"
   givenUrl: Url!
-  itemId: ID! @shareable
+  itemId: String! @shareable
 
   #Note more properties exist here but are defined in another service.
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,7 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.0",
+        import: ["@key", "@shareable", "@tag"])
+
 """
 ISOString scalar - all datetimes fields are Typescript Date objects on this server &
 returned as ISO-8601 encoded date strings (e.g. ISOString scalars) to GraphQL clients.
@@ -106,7 +110,7 @@ input PaginationInput {
 }
 
 extend type CorpusItem @key(fields: "url") {
-  url: Url! @external
+  url: Url!
 
   """
   The user's saved item, from the Corpus Item, if the corpus item was saved to the user's saves
@@ -484,13 +488,13 @@ type SavedItemTagAssociation {
   tagId: ID!
 }
 
-extend type User @key(fields: "id") {
+type User @key(fields: "id") {
   #Note more properties exist here but are defined in another service.
 
   """
   User id, provided by the user service.
   """
-  id: ID! @external
+  id: ID!
 
   """
   Get a general paginated listing of all SavedItems for the user
@@ -538,13 +542,15 @@ type PendingItem @key(fields: "url") {
   URL of the item that the user gave for the SavedItem
   that is pending processing by parser
   """
+  itemId: ID!
   url: Url!
   status: PendingItemStatus
 }
 
-extend type Item @key(fields: "givenUrl") {
+type Item @key(fields: "givenUrl") {
   "key field to identify the Item entity in the Parser service"
-  givenUrl: Url! @external
+  givenUrl: Url!
+  itemId: ID! @shareable
 
   #Note more properties exist here but are defined in another service.
 
@@ -756,6 +762,13 @@ type PocketSave {
   The Tags associated with this PocketSave.
   """
   tags: [Tag!]
+
+  """
+  Link to the underlying Pocket Item for the URL. 
+  Temporary until resource field is added. Will hopefully
+  make it easier for clients to adopt.
+  """
+  item: ItemResult! @deprecated(reason: "use resource")
 
   # Not resolved on this subgraph.
   # """

--- a/src/models/item.spec.ts
+++ b/src/models/item.spec.ts
@@ -1,0 +1,67 @@
+import { PendingItemStatus } from '../types';
+import { ItemModel } from './item';
+
+describe('ItemModel', () => {
+  describe('getBySave', () => {
+    it('returns PendingItem if resolvedId is null', () => {
+      const save = {
+        givenUrl: 'https://www.youtube.com/watch?v=YyknBTm_YyM',
+        id: '123',
+        resolvedId: null,
+      };
+      const expected = {
+        itemId: '123',
+        url: 'https://www.youtube.com/watch?v=YyknBTm_YyM',
+        __typename: 'PendingItem',
+        status: PendingItemStatus.UNRESOLVED,
+      };
+      const actual = new ItemModel().getBySave(save);
+      expect(actual).toStrictEqual(expected);
+    });
+    it('returns PendingItem if resolvedId is undefined', () => {
+      const save = {
+        givenUrl: 'https://www.youtube.com/watch?v=YyknBTm_YyM',
+        id: '123',
+        resolvedId: null,
+      };
+      const expected = {
+        itemId: '123',
+        url: 'https://www.youtube.com/watch?v=YyknBTm_YyM',
+        status: PendingItemStatus.UNRESOLVED,
+        __typename: 'PendingItem',
+      };
+      const actual = new ItemModel().getBySave(save);
+      expect(actual).toStrictEqual(expected);
+    });
+    it('returns PendingItem if resolvedId is 0', () => {
+      const save = {
+        givenUrl: 'https://www.youtube.com/watch?v=YyknBTm_YyM',
+        id: '123',
+        resolvedId: null,
+      };
+      const expected = {
+        itemId: '123',
+        url: 'https://www.youtube.com/watch?v=YyknBTm_YyM',
+        __typename: 'PendingItem',
+        status: PendingItemStatus.UNRESOLVED,
+      };
+      const actual = new ItemModel().getBySave(save);
+      expect(actual).toStrictEqual(expected);
+    });
+    it('returns Item if resolvedId is not null', () => {
+      const savedItem = {
+        url: 'https://www.youtube.com/watch?v=nsNMP6_Q0Js',
+        id: '123',
+        resolvedId: '123',
+      };
+      const expected = {
+        givenUrl: 'https://www.youtube.com/watch?v=nsNMP6_Q0Js',
+        itemId: '123',
+        resolvedId: '123',
+        __typename: 'Item',
+      };
+      const actual = new ItemModel().getBySave(savedItem);
+      expect(actual).toStrictEqual(expected);
+    });
+  });
+});

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -1,0 +1,44 @@
+import {
+  SavedItem,
+  PocketSave,
+  PendingItemStatus,
+  PendingItem,
+  Item,
+} from '../types';
+
+export class ItemModel {
+  /**
+   * Resolve Item/Pending Item on a Save. If the Item has been fully
+   * processed by the Parser, the Save parent will have a resolvedId
+   * for the Item; otherwise it is a PendingItem.
+   * @param parent the SavedItem/PocketSave entity to resolve Item for
+   * @returns the Item | PendingItem (if not yet processed) result
+   */
+  public getBySave(
+    parent:
+      | Pick<SavedItem, 'url' | 'id' | 'resolvedId'>
+      | Pick<PocketSave, 'givenUrl' | 'id' | 'resolvedId'>
+  ): Item | PendingItem {
+    let url: string;
+    if ('url' in parent) {
+      url = parent.url;
+    } else if ('givenUrl' in parent) {
+      url = parent.givenUrl;
+    }
+    if (parseInt(parent.resolvedId)) {
+      return {
+        __typename: 'Item',
+        givenUrl: url,
+        itemId: parent.id,
+        resolvedId: parent.resolvedId,
+      };
+    }
+    // resolvedId was null/undefined/0
+    return {
+      __typename: 'PendingItem',
+      url,
+      itemId: parent.id,
+      status: PendingItemStatus.UNRESOLVED,
+    };
+  }
+}

--- a/src/models/pocketSave.spec.ts
+++ b/src/models/pocketSave.spec.ts
@@ -38,6 +38,7 @@ describe('PocketSaveModel', () => {
         status: 'UNREAD',
         title: 'puppies',
         updatedAt: new Date('2012-08-13 15:32:05'),
+        resolvedId: '1',
       };
       expect(output).toStrictEqual(expected);
     });
@@ -72,6 +73,7 @@ describe('PocketSaveModel', () => {
         status: 'ARCHIVED',
         title: 'puppies',
         updatedAt: dateUpdated,
+        resolvedId: '1',
       };
       expect(output).toStrictEqual(expected);
     });

--- a/src/models/pocketSave.ts
+++ b/src/models/pocketSave.ts
@@ -29,6 +29,7 @@ export class PocketSaveModel {
       favoritedAt: row.favorite === 1 ? row.time_favorited : null,
       givenUrl: row.given_url,
       id: row.item_id.toString(),
+      resolvedId: row.resolved_id.toString() ?? null,
       status: row.status,
       title: row.title,
       updatedAt: row.time_updated,

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -26,7 +26,7 @@ import {
   Item,
   PocketSave,
   SaveWriteMutationPayload,
-  SavedItem,
+  PendingItem,
   Tag,
   SaveMutationInput,
 } from '../types';
@@ -42,8 +42,8 @@ const resolvers = {
     },
   },
   ItemResult: {
-    __resolveType(savedItem: SavedItem) {
-      return parseInt(savedItem.resolvedId) ? 'Item' : 'PendingItem';
+    __resolveType(parent: PendingItem | Item) {
+      return parent.__typename;
     },
   },
   User: {
@@ -78,6 +78,9 @@ const resolvers = {
     },
     tags(parent: PocketSave, _args: any, context: IContext) {
       return context.models.tag.getBySaveId(parent.id);
+    },
+    item(parent: PocketSave, _args: any, context: IContext) {
+      return context.models.item.getBySave(parent);
     },
   },
   SavedItem: {

--- a/src/resolvers/savedItem.ts
+++ b/src/resolvers/savedItem.ts
@@ -47,12 +47,14 @@ export async function item(parent: SavedItem): Promise<Item | PendingItem> {
   if (parseInt(parent.resolvedId)) {
     return {
       __typename: 'Item',
+      itemId: parent.id,
       givenUrl: parent.url,
       resolvedId: parent.resolvedId,
     };
   }
   return {
     __typename: 'PendingItem',
+    itemId: parent.id,
     url: parent.url,
     status: PendingItemStatus.UNRESOLVED,
   };

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -14,6 +14,7 @@ import { TagModel } from '../models';
 import * as Sentry from '@sentry/node';
 import { PocketSaveModel } from '../models/pocketSave';
 import { BaseErrorModel } from '../models/baseError';
+import { ItemModel } from '../models/item';
 
 export interface IContext {
   userId: string;
@@ -26,6 +27,7 @@ export interface IContext {
     tag: TagModel;
     pocketSave: PocketSaveModel;
     baseError: BaseErrorModel;
+    item: ItemModel;
   };
   dataLoaders: {
     savedItemsById: DataLoader<string, SavedItem>;
@@ -58,12 +60,14 @@ export class ContextManager implements IContext {
       ...createSavedItemDataLoaders(this),
     };
     this.models = {
+      item: new ItemModel(),
       tag: new TagModel(this),
       pocketSave: new PocketSaveModel(this),
       baseError: new BaseErrorModel(),
     };
   }
   models: {
+    item: ItemModel;
     tag: TagModel;
     pocketSave: PocketSaveModel;
     baseError: BaseErrorModel;

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -210,9 +210,12 @@ describe('UpsertSavedItem Mutation', () => {
             id
             item {
               ... on Item {
+                __typename
                 givenUrl
               }
               ... on PendingItem {
+                __typename
+                itemId
                 url
               }
             }
@@ -229,6 +232,8 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.id).to.equal('1');
       expect(data.item.givenUrl).is.undefined;
       expect(data.item.url).to.equal(givenUrl);
+      expect(data.item.itemId).to.equal('1');
+      expect(data.item.__typename).to.equal('PendingItem');
     });
 
     it('should updated time favourite and time updated if provided in input', async () => {

--- a/src/test/graphql/queries/pocketSave-item.integration.ts
+++ b/src/test/graphql/queries/pocketSave-item.integration.ts
@@ -1,0 +1,125 @@
+import { ApolloServer } from '@apollo/server';
+import { ContextManager } from '../../../server/context';
+import { readClient } from '../../../database/client';
+import { startServer } from '../../../server/apollo';
+import { Express } from 'express';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+
+describe('PocketSave.Item', () => {
+  const db = readClient();
+  const headers = { userid: '1' };
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const GET_ITEM_POCKET_SAVE = gql`
+    query getPocketSave($userId: ID!, $itemId: ID!) {
+      _entities(representations: { id: $userId, __typename: "User" }) {
+        ... on User {
+          saveById(id: $itemId) {
+            item {
+              ... on PendingItem {
+                itemId
+                url
+                status
+                __typename
+              }
+              ... on Item {
+                itemId
+                givenUrl
+                __typename
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  afterAll(async () => {
+    await db.destroy();
+    await server.stop();
+  });
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+    await db('list').truncate();
+    await db('list').insert([
+      {
+        api_id: '012',
+        api_id_updated: '012',
+        favorite: 0,
+        given_url: 'https://www.youtube.com/watch?v=nsNMP6_Q0Js',
+        item_id: 55,
+        resolved_id: 55,
+        status: 0,
+        time_added: new Date(),
+        time_favorited: new Date(),
+        time_read: new Date(),
+        time_updated: new Date(),
+        title: `Mon Coeur s'ouvre a ta voix`,
+        user_id: 1,
+      },
+      {
+        api_id: '012',
+        api_id_updated: '012',
+        favorite: 0,
+        given_url: 'https://www.youtube.com/watch?v=w8tVsfPPxyU',
+        item_id: 22,
+        resolved_id: 0,
+        status: 0,
+        time_added: new Date(),
+        time_favorited: new Date(),
+        time_read: new Date(),
+        time_updated: new Date(),
+        title: `Un bel dì vedremo`,
+        user_id: 1,
+      },
+    ]);
+  });
+  it('returns a PendingItem if resolvedId is 0', async () => {
+    const variables = {
+      userId: '1',
+      itemId: '22',
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(GET_ITEM_POCKET_SAVE),
+        variables,
+      });
+    const expected = {
+      status: 'UNRESOLVED',
+      itemId: '22',
+      url: 'https://www.youtube.com/watch?v=w8tVsfPPxyU',
+      __typename: 'PendingItem',
+    };
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data._entities[0].saveById.item).toStrictEqual(expected);
+  });
+  it('returns an Item if resolvedId is nonzero integer', async () => {
+    const variables = {
+      userId: '1',
+      itemId: '55',
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(GET_ITEM_POCKET_SAVE),
+        variables,
+      });
+    const expected = {
+      itemId: '55',
+      givenUrl: 'https://www.youtube.com/watch?v=nsNMP6_Q0Js',
+      __typename: 'Item',
+    };
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data._entities[0].saveById.item).toStrictEqual(expected);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,7 @@ export type RemoteEntity = {
 export type Item = {
   __typename: string;
   givenUrl: string;
+  itemId: string;
   resolvedId: string;
 };
 
@@ -43,6 +44,7 @@ export enum PendingItemStatus {
 
 export type PendingItem = {
   __typename: string;
+  itemId: string;
   url: string;
   status?: PendingItemStatus;
 };
@@ -202,6 +204,7 @@ export type PocketSave = {
   favoritedAt: Date | null;
   givenUrl: string;
   id: string;
+  resolvedId: string | null;
   status: keyof typeof PocketSaveStatus;
   suggestedTags?: Tag[];
   tags?: Tag[];


### PR DESCRIPTION
## Goal
Add itemId to Item and PendingItem

- Resolve the type with the __typename field we already provide from the Item resolver function
- Add ItemModel with method for resolving an Item on a PocketSave
- Use fed2 directives because itemId is now `@shareable` on Item

~Edit: Need a little work to get the schema to compose after the fed2 move, but all other code is ready~ Fixed

## I'd love feedback/perspectives on:
- Including on PocketResource

## Implementation Decisions
- I added the item field to PocketSave, although it will be superseded by `resource` according to the contract. I can remove it if we want.


[INFRA-1040]

[INFRA-1040]: https://getpocket.atlassian.net/browse/INFRA-1040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ