### PR TITLE
feat(unfave): ability to unfavorite a pocketsave

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -656,9 +656,14 @@ type Mutation {
   saveArchive(id: [ID!]!, timestamp: ISOString!): SaveWriteMutationPayload @tag(name: "alpha")
   """
   Favorites PocketSaves
-  Fetches the list of Ids that we want to save.
+  Accepts a list of PocketSave Ids that we want to favorite.
   """
   saveFavorite(id: [ID!]!, timestamp: ISOString!): SaveWriteMutationPayload @tag(name: "alpha")
+  """
+  Unfavorites PocketSaves
+  Accepts a list of PocketSave Ids that we want to unfavorite.
+  """
+  saveUnFavorite(id: [ID!]!, timestamp: ISOString!): SaveWriteMutationPayload @tag(name: "alpha")
 }
 
 # """

--- a/src/models/pocketSave.ts
+++ b/src/models/pocketSave.ts
@@ -95,9 +95,10 @@ export class PocketSaveModel {
    * bulk favorite the saves
    * no action performed if saves are already favorited
    * any error in the batch will rollback and fail the entire batch
-   * @param ids itemIds associated to the saves to archive; must all be
+   * @param ids itemIds associated to the saves to favorite; must all be
    * valid or the operation will fail.
    * @param timestamp timestamp for when the bulk operation occurred
+   * @param path GraphQL path for the operation
    * @returns  SaveWriteMutationPayload the saves that were updated,
    * and any errors that occurred
    */
@@ -108,6 +109,32 @@ export class PocketSaveModel {
   ): Promise<SaveWriteMutationPayload> {
     const uniqueIds = uniqueArray(ids.map((id) => parseInt(id)));
     const { updated, missing } = await this.saveService.favoriteListRow(
+      uniqueIds,
+      timestamp
+    );
+    const payload = this.formatSaveWriteMutationPayload(missing, updated, path);
+    //todo: emit event
+    return payload;
+  }
+
+  /**
+   * bulk unfavorite the saves
+   * no action performed if saves are already unfavorited
+   * any error in the batch will rollback and fail the entire batch
+   * @param ids itemIds associated to the saves to unfavorite; must all be
+   * valid or the operation will fail.
+   * @param timestamp timestamp for when the bulk operation occurred
+   * @param path GraphQL path for the operation
+   * @returns  SaveWriteMutationPayload the saves that were updated,
+   * and any errors that occurred
+   */
+  public async saveUnFavorite(
+    ids: string[],
+    timestamp: Date,
+    path: GraphQLResolveInfo['path']
+  ): Promise<SaveWriteMutationPayload> {
+    const uniqueIds = uniqueArray(ids.map((id) => parseInt(id)));
+    const { updated, missing } = await this.saveService.unFavoriteListRow(
       uniqueIds,
       timestamp
     );

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -142,6 +142,18 @@ const resolvers = {
         info.path
       );
     },
+    saveUnFavorite: async (
+      _,
+      args: SaveMutationInput,
+      context: IContext,
+      info: GraphQLResolveInfo
+    ): Promise<SaveWriteMutationPayload> => {
+      return await context.models.pocketSave.saveUnFavorite(
+        args.id,
+        args.timestamp,
+        info.path
+      );
+    },
   },
 };
 

--- a/src/test/graphql/mutations/save-unfavorite.integration.ts
+++ b/src/test/graphql/mutations/save-unfavorite.integration.ts
@@ -1,0 +1,181 @@
+import { writeClient } from '../../../database/client';
+import sinon from 'sinon';
+import { ContextManager } from '../../../server/context';
+import { startServer } from '../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+
+describe('saveUnFavorite mutation', function () {
+  const db = writeClient();
+  const headers = { userid: '1' };
+  const date = new Date('2020-10-03T10:20:30.000Z'); // Consistent date for seeding
+  const date1 = new Date('2020-10-03T10:30:30.000Z'); // Consistent date for seeding
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const SAVE_UNFAVORITE = gql`
+    mutation saveUnFavorite($id: [ID!]!, $timestamp: ISOString!) {
+      saveUnFavorite(id: $id, timestamp: $timestamp) {
+        save {
+          id
+          favorite
+          favoritedAt
+          updatedAt
+        }
+        errors {
+          __typename
+          ... on BaseError {
+            path
+            message
+          }
+        }
+      }
+    }
+  `;
+
+  beforeEach(async () => {
+    await db('list').truncate();
+    const inputData = [
+      { item_id: 0, favorite: 1 },
+      { item_id: 1, favorite: 1 },
+      { item_id: 2, favorite: 0 },
+    ].map((row) => {
+      return {
+        ...row,
+        status: 0,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date1,
+        time_read: date,
+        time_favorited: row.favorite === 1 ? date : '0000-00-00 00:00:00',
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await db('list').insert(inputData);
+  });
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+    sinon.restore();
+    await server.stop();
+  });
+
+  afterEach(() => sinon.resetHistory());
+
+  it('should unfavorite one save', async () => {
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      id: ['1'],
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(SAVE_UNFAVORITE), variables });
+
+    expect(res).not.toBeUndefined();
+    expect(res.body.data.saveUnFavorite.save).toBeArrayOfSize(1);
+    expect(res.body.data.saveUnFavorite.errors).toBeArrayOfSize(0);
+    const actual = res.body.data.saveUnFavorite.save[0];
+    expect(actual).toStrictEqual({
+      id: '1',
+      favorite: false,
+      favoritedAt: null,
+      updatedAt: testTimestamp,
+    });
+  });
+
+  it('should unfavorite multiple saves', async () => {
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      id: ['0', '1'],
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(SAVE_UNFAVORITE), variables });
+
+    const expected = {
+      save: [
+        {
+          id: '0',
+          favorite: false,
+          favoritedAt: null,
+          updatedAt: testTimestamp,
+        },
+        {
+          id: '1',
+          favorite: false,
+          favoritedAt: null,
+          updatedAt: testTimestamp,
+        },
+      ],
+      errors: [],
+    };
+    const data = res.body.data.saveUnFavorite;
+    expect(data.save).toIncludeSameMembers(expected.save);
+    expect(data.errors).toBeArrayOfSize(0);
+  });
+
+  it('should fail the entire batch if one fails (NOT_FOUND)', async () => {
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      id: ['123123'],
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(SAVE_UNFAVORITE), variables });
+
+    expect(res).not.toBeUndefined();
+    expect(res.body.data.saveUnFavorite.save).toBeArrayOfSize(0);
+    const errors = res.body.data.saveUnFavorite.errors;
+    expect(errors).toBeArrayOfSize(1);
+    expect(errors[0]).toStrictEqual({
+      __typename: 'NotFound',
+      message: 'Entity identified by key=id, value=123123 was not found.',
+      path: 'saveUnFavorite',
+    });
+  });
+
+  it('should not fail if trying to unfavorite a save that is already unfavorited (no-op)', async () => {
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      id: ['2'],
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(SAVE_UNFAVORITE), variables });
+
+    const data = res.body.data.saveUnFavorite.save;
+    expect(data).toMatchObject([
+      {
+        favorite: false,
+        favoritedAt: null,
+      },
+    ]);
+    expect(res.body.data.saveUnFavorite.errors).toBeArrayOfSize(0);
+  });
+  //todo: event emission
+  //todo: constraint validation
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "@pocket-tools/tsconfig",
+  "esModuleInterop": true,
   "compilerOptions": {
     "outDir": "dist",
     "rootDirs": ["src", "lambda"]


### PR DESCRIPTION
## Goal

Adds a mutation to unfavorite a PocketSave entity.

Does not add emission of events yet given separate discussion that moved that to another ticket.

## I'd love feedback/perspectives on:
i was half tempted to simply add a 'favorite/unfavorite' argument to the existing favoriteListRow && saveFavorite methods, but decided to go more explicit (and verbose). but not opposed to merging these however.

## References

Jira ticket:
* https://getpocket.atlassian.net/browse/INFRA-546
