### PR TITLE
feat(unarchive): ability to unarchive a pocketsave

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - .env
     environment:
       - NODE_ENV=local
+      - TZ=US/Central
     entrypoint: ./.docker/scripts/local-start.sh
     depends_on:
       - mysql

--- a/schema.graphql
+++ b/schema.graphql
@@ -652,13 +652,18 @@ type Mutation {
   """
   replaceSavedItemTags(input: [SavedItemTagsInput!]!): [SavedItem!]!
 
-  """Archives a Save"""
+  """Archives PocketSaves"""
   saveArchive(id: [ID!]!, timestamp: ISOString!): SaveWriteMutationPayload @tag(name: "alpha")
+
+  """Unarchives PocketSaves"""
+  saveUnArchive(id: [ID!]!, timestamp: ISOString!): SaveWriteMutationPayload @tag(name: "alpha")
+
   """
   Favorites PocketSaves
   Accepts a list of PocketSave Ids that we want to favorite.
   """
   saveFavorite(id: [ID!]!, timestamp: ISOString!): SaveWriteMutationPayload @tag(name: "alpha")
+
   """
   Unfavorites PocketSaves
   Accepts a list of PocketSave Ids that we want to unfavorite.

--- a/src/models/pocketSave.ts
+++ b/src/models/pocketSave.ts
@@ -67,6 +67,7 @@ export class PocketSaveModel {
    * @param ids itemIds associated to the saves to archive; must all be
    * valid or the operation will fail.
    * @param timestamp timestamp for when the bulk operation occurred
+   * @param path GraphQL path for the operation
    * @returns SaveWriteMutationPayload the saves that were updated,
    * and any errors that occurred
    */
@@ -88,6 +89,34 @@ export class PocketSaveModel {
     // Hydrate errors path with current location
     // Resolved on saveArchive because it needs to be aware
     // of this path, not the path of the error resolver type
+    return payload;
+  }
+
+  /**
+   * Bulk update method for unarchiving saves; if the save is already
+   * unarchived, will be a no-op and no changes will occur.
+   * All IDs passed to this function must be valid; if any are not
+   * found in the user's saves, the entire operation will be rolled
+   * back and NotFound payload returned.
+   * @param ids itemIds associated to the saves to archive; must all be
+   * valid or the operation will fail.
+   * @param timestamp timestamp for when the bulk operation occurred
+   * @param path GraphQL path for the operation
+   * @returns SaveWriteMutationPayload the saves that were updated,
+   * and any errors that occurred
+   */
+  public async saveUnArchive(
+    ids: string[],
+    timestamp: Date,
+    path: GraphQLResolveInfo['path']
+  ): Promise<SaveWriteMutationPayload> {
+    const uniqueIds = uniqueArray(ids.map((id) => parseInt(id)));
+    const { updated, missing } = await this.saveService.unArchiveListRow(
+      uniqueIds,
+      timestamp
+    );
+    const payload = this.formatSaveWriteMutationPayload(missing, updated, path);
+    // TODO: Emit events
     return payload;
   }
 

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -130,6 +130,18 @@ const resolvers = {
         info.path
       );
     },
+    saveUnArchive: async (
+      _,
+      args: SaveMutationInput,
+      context: IContext,
+      info: GraphQLResolveInfo
+    ): Promise<SaveWriteMutationPayload> => {
+      return await context.models.pocketSave.saveUnArchive(
+        args.id,
+        args.timestamp,
+        info.path
+      );
+    },
     saveFavorite: async (
       _,
       args: SaveMutationInput,

--- a/src/test/graphql/mutations/save-unarchive.integration.ts
+++ b/src/test/graphql/mutations/save-unarchive.integration.ts
@@ -1,0 +1,180 @@
+import { writeClient } from '../../../database/client';
+import sinon from 'sinon';
+import { ContextManager } from '../../../server/context';
+import { startServer } from '../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+
+describe('saveUnArchive mutation', function () {
+  const db = writeClient();
+  const headers = { userid: '1' };
+  const date = new Date('2020-10-03T10:20:30.000Z'); // Consistent date for seeding
+  const date1 = new Date('2020-10-03T10:30:30.000Z'); // Consistent date for seeding
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const UNARCHIVE_MUTATION = gql`
+    mutation saveUnArchive($id: [ID!]!, $timestamp: ISOString!) {
+      saveUnArchive(id: $id, timestamp: $timestamp) {
+        save {
+          id
+          archived
+          archivedAt
+          updatedAt
+        }
+        errors {
+          __typename
+          ... on BaseError {
+            path
+            message
+          }
+        }
+      }
+    }
+  `;
+
+  beforeEach(async () => {
+    await db('list').truncate();
+    const inputData = [
+      { item_id: 0, status: 1, favorite: 0 },
+      { item_id: 1, status: 1, favorite: 0 },
+      { item_id: 2, status: 0, favorite: 1 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date1,
+        time_read: row.status === 1 ? date : '0000-00-00 00:00:00',
+        time_favorited: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await db('list').insert(inputData);
+  });
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+    sinon.restore();
+    await server.stop();
+  });
+
+  afterEach(() => sinon.resetHistory());
+
+  it('should unarchive one save', async () => {
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      id: ['1'],
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNARCHIVE_MUTATION), variables });
+
+    expect(res).not.toBeUndefined();
+    expect(res.body.data.saveUnArchive.save).toBeArrayOfSize(1);
+    expect(res.body.data.saveUnArchive.errors).toBeArrayOfSize(0);
+    const actual = res.body.data.saveUnArchive.save[0];
+    expect(actual).toStrictEqual({
+      id: '1',
+      archived: false,
+      archivedAt: null,
+      updatedAt: testTimestamp,
+    });
+  });
+
+  it('should fail the entire batch if one fails (NOT_FOUND)', async () => {
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      id: ['123123'],
+      timestamp: testTimestamp,
+      updatedAt: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNARCHIVE_MUTATION), variables });
+
+    expect(res).not.toBeUndefined();
+    expect(res.body.data.saveUnArchive.save).toBeArrayOfSize(0);
+    const errors = res.body.data.saveUnArchive.errors;
+    expect(errors).toBeArrayOfSize(1);
+    expect(errors[0]).toStrictEqual({
+      __typename: 'NotFound',
+      message: 'Entity identified by key=id, value=123123 was not found.',
+      path: 'saveUnArchive',
+    });
+  });
+
+  it('should unarchive multiple saves', async () => {
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      id: ['0', '1'],
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNARCHIVE_MUTATION), variables });
+
+    const expected = {
+      save: [
+        {
+          id: '0',
+          archived: false,
+          archivedAt: null,
+          updatedAt: testTimestamp,
+        },
+        {
+          id: '1',
+          archived: false,
+          archivedAt: null,
+          updatedAt: testTimestamp,
+        },
+      ],
+      errors: [],
+    };
+    const data = res.body.data.saveUnArchive;
+    expect(data.save).toIncludeSameMembers(expected.save);
+    expect(data.errors).toBeArrayOfSize(0);
+  });
+
+  it('should not fail if trying to unarchive a save that is already archived (no-op)', async () => {
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      id: ['2'],
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNARCHIVE_MUTATION), variables });
+
+    const data = res.body.data.saveUnArchive.save;
+    expect(data).toMatchObject([
+      {
+        archived: false,
+        archivedAt: null,
+        updatedAt: date1.toISOString(),
+      },
+    ]);
+    expect(res.body.data.saveUnArchive.errors).toBeArrayOfSize(0);
+  });
+});


### PR DESCRIPTION
## Goal

Add ability to unarchive a PocketSave or list of PocketSaves.

Also set the app TZ for the docker-compose setup to US/Central as well, as it was showing errors running locally (undesired timezone shifts). See impl notes for more details on this.

## I'd love feedback/perspectives on:
- again, the main push of this PR is just copy & pasting & altering with a 'un' the archive stuff already existing, but i'm open to cutting down on verbosity & just adding on/off arguments to existing functions

## Implementation Decisions
- i did investigate whether or not we could get away from forcing all app servers using this code to be in the same TZ (system-wide) by using the MySQL package ConnectionConfig.timezone option. Unfortunately, it just doesn't work with negative offsets. Plus with this route, we'd have to manage DST changes ourselves. It  would obviate the need for setting system TZs everyone, but unfortunately, isn't currently usable.

## References

Jira ticket:
* https://getpocket.atlassian.net/browse/INFRA-544
