### PR TITLE
feat(upsertSavedItem): [INFRA-1195] Add title field to upsertSavedItem mutation

### DIFF
--- a/.circleci/scripts/setup_aws.sh
+++ b/.circleci/scripts/setup_aws.sh
@@ -5,7 +5,7 @@ sudo apt-get update && sudo apt-get install -y python3-pip
 # 2022-12-01 - awscli is pinned to fix a build error with 1.27.1 related to
 # not finding a botocore version = 1.29.21. this can probably be
 # un-pinned in the future?
-pip3 install awscli-local awscli==1.27.20
+pip3 install boto3==1.26.90 awscli-local awscli==1.27.20
 
 
 for Script in .docker/localstack/*.sh ; do

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:dev": "npm run build && npm run watch",
     "test-ci": "npm test",
     "test": "jest \"\\.spec\\.ts\"",
-    "test-integrations": "jest \"\\.integration\\.ts\" --runInBand",
+    "test-integrations": "jest savedItemsMutationService-upsert.integration.ts --runInBand",
     "lint-check": "eslint --fix-dry-run \"src/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**/*.ts\""
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:dev": "npm run build && npm run watch",
     "test-ci": "npm test",
     "test": "jest \"\\.spec\\.ts\"",
-    "test-integrations": "jest savedItemsMutationService-upsert.integration.ts --runInBand",
+    "test-integrations": "jest \"\\.integration\\.ts\" --runInBand",
     "lint-check": "eslint --fix-dry-run \"src/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**/*.ts\""
   },

--- a/schema.graphql
+++ b/schema.graphql
@@ -145,6 +145,10 @@ type SavedItem implements RemoteEntity @key(fields: "id") @key(fields: "url") {
   """
   url: String!
   """
+  The title for user saved item. Set by the user and if not, set by the parser
+  """
+  title: String
+  """
   Helper property to indicate if the SavedItem is favorited
   """
   isFavorite: Boolean!
@@ -249,6 +253,10 @@ input SavedItemUpsertInput {
   Optional, time that request was submitted by client epoch/unix time
   """
   timestamp: Int
+  """
+  Optional, title of the SavedItem
+  """
+  title: String
 }
 
 """

--- a/src/dataService/savedItemsService.ts
+++ b/src/dataService/savedItemsService.ts
@@ -89,6 +89,7 @@ export class SavedItemDataService {
       'item_id AS id',
       'resolved_id AS resolvedId', // for determining if an item is pending
       'favorite as isFavorite',
+      'title',
       this.db.raw(
         'CASE WHEN favorite = 1 THEN UNIX_TIMESTAMP(time_favorited) ELSE null END as favoritedAt '
       ),

--- a/src/resolvers/mutation.ts
+++ b/src/resolvers/mutation.ts
@@ -35,10 +35,16 @@ export async function upsertSavedItem(
   const savedItemDataService = new SavedItemDataService(context);
 
   try {
-    const item = await ParserCaller.getOrCreateItem(savedItemUpsertInput.url);
+    //TODO do we need the resolved id @Herraj
+    let item = await ParserCaller.getOrCreateItem(savedItemUpsertInput.url);
     const existingItem = await savedItemDataService.getSavedItemById(
       item.itemId.toString()
     );
+
+    // if title is provided in the mutation input then use that and not the one received by the parser call
+    if (savedItemUpsertInput.title) {
+      item = { ...item, title: savedItemUpsertInput.title };
+    }
     // Keep track of whether the request was originally to favorite an item,
     // and whether it's a new favorite or item was favorited already
     const shouldSendFavoriteEvent =

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -154,6 +154,7 @@ describe('UpsertSavedItem Mutation', () => {
           upsertSavedItem(input: { url: $url }) {
             id
             url
+            title
             _createdAt
             _updatedAt
             favoritedAt
@@ -181,6 +182,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(mutationResult).is.not.null;
       const data = mutationResult.body.data?.upsertSavedItem;
       expect(data.id).to.equal('8');
+      expect(data.title).to.equal(variables.url); // in the mockParserGetItemRequest call in the beforeAll, we are returning title as the url
       expect(data.url).to.equal(variables.url);
       expect(data.isFavorite).is.false;
       expect(data.isArchived).is.false;
@@ -190,6 +192,29 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.tags[0].name).equals('zebra');
       expect(data.archivedAt).is.null;
       expect(data.favoritedAt).is.null;
+    });
+
+    it('should return user provided title on the returned savedItem', async () => {
+      const variables = {
+        url: 'http://getpocket.com',
+        title: 'test-user-title',
+      };
+
+      const ADD_AN_ITEM = `
+        mutation addAnItem($url: String!, $title: String) {
+          upsertSavedItem(input: { url: $url, title: $title }) {
+            title
+          }
+        }
+      `;
+
+      const mutationResult = await request(app).post(url).set(headers).send({
+        query: ADD_AN_ITEM,
+        variables,
+      });
+      expect(mutationResult).is.not.null;
+      const data = mutationResult.body.data?.upsertSavedItem;
+      expect(data.title).to.equal(variables.title);
     });
 
     it('should add an item to the list even if the parser has not yet resolved or cannot resolve it', async () => {

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -144,7 +144,7 @@ describe('UpsertSavedItem Mutation', () => {
       );
     });
 
-    it('should add a valid item and return savedItem', async () => {
+    it.only('should add a valid item and return savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',
       };
@@ -154,6 +154,7 @@ describe('UpsertSavedItem Mutation', () => {
           upsertSavedItem(input: { url: $url }) {
             id
             url
+            title
             _createdAt
             _updatedAt
             favoritedAt
@@ -181,7 +182,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(mutationResult).is.not.null;
       const data = mutationResult.body.data?.upsertSavedItem;
       expect(data.id).to.equal('8');
-      // expect(data.title).to.equal(variables.url); // in the mockParserGetItemRequest call in the beforeAll, we are returning title as the url
+      expect(data.title).to.equal(variables.url);
       expect(data.url).to.equal(variables.url);
       expect(data.isFavorite).is.false;
       expect(data.isArchived).is.false;
@@ -193,9 +194,9 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.favoritedAt).is.null;
     });
 
-    it.skip('should return user provided title on the returned savedItem', async () => {
+    it('should return user provided title on the returned savedItem', async () => {
       const variables = {
-        url: 'http://testing-title.com',
+        url: 'http://getpocket.com',
         title: 'test-user-title',
       };
 
@@ -470,7 +471,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(permLibQueueBody.timeAdded).equals('2021-10-06 03:22:00');
       expect(permLibQueueBody.resolvedId).equals(25);
     });
-    describe(' - on existing savedItem: ', () => {
+    describe.skip(' - on existing savedItem: ', () => {
       const ADD_AN_ITEM = `
         mutation addAnItem(
           $url: String!
@@ -649,7 +650,7 @@ describe('UpsertSavedItem Mutation', () => {
       });
     });
   });
-  describe('sad path', function () {
+  describe.skip('sad path', function () {
     it('should return error for invalid url', async () => {
       mockParserGetItemRequest('abcde1234', {
         item: {

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -144,7 +144,7 @@ describe('UpsertSavedItem Mutation', () => {
       );
     });
 
-    it('should add a valid item and return savedItem', async () => {
+    it.skip('should add a valid item and return savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',
       };
@@ -194,7 +194,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.favoritedAt).is.null;
     });
 
-    it('should return user provided title on the returned savedItem', async () => {
+    it.only('should return user provided title on the returned savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',
         title: 'test-user-title',
@@ -471,7 +471,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(permLibQueueBody.timeAdded).equals('2021-10-06 03:22:00');
       expect(permLibQueueBody.resolvedId).equals(25);
     });
-    describe(' - on existing savedItem: ', () => {
+    describe.skip(' - on existing savedItem: ', () => {
       const ADD_AN_ITEM = `
         mutation addAnItem(
           $url: String!
@@ -650,7 +650,7 @@ describe('UpsertSavedItem Mutation', () => {
       });
     });
   });
-  describe('sad path', function () {
+  describe.skip('sad path', function () {
     it('should return error for invalid url', async () => {
       mockParserGetItemRequest('abcde1234', {
         item: {

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -144,7 +144,7 @@ describe('UpsertSavedItem Mutation', () => {
       );
     });
 
-    it.only('should add a valid item and return savedItem', async () => {
+    it('should add a valid item and return savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',
       };
@@ -194,7 +194,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.favoritedAt).is.null;
     });
 
-    it('should return user provided title on the returned savedItem', async () => {
+    it.only('should return user provided title on the returned savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',
         title: 'test-user-title',

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -131,10 +131,6 @@ describe('UpsertSavedItem Mutation', () => {
           url: 'http://write-client.com',
           itemId: 50,
         },
-        {
-          url: 'http://testing-title.com',
-          itemId: 19,
-        },
       ];
       mockRequestData.forEach(({ url, itemId }) =>
         mockParserGetItemRequest(url, {
@@ -148,7 +144,7 @@ describe('UpsertSavedItem Mutation', () => {
       );
     });
 
-    it.only('should add a valid item and return savedItem', async () => {
+    it('should add a valid item and return savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',
       };
@@ -158,7 +154,6 @@ describe('UpsertSavedItem Mutation', () => {
           upsertSavedItem(input: { url: $url }) {
             id
             url
-            title
             _createdAt
             _updatedAt
             favoritedAt
@@ -186,7 +181,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(mutationResult).is.not.null;
       const data = mutationResult.body.data?.upsertSavedItem;
       expect(data.id).to.equal('8');
-      expect(data.title).to.equal(variables.url); // in the mockParserGetItemRequest call in the beforeAll, we are returning title as the url
+      // expect(data.title).to.equal(variables.url); // in the mockParserGetItemRequest call in the beforeAll, we are returning title as the url
       expect(data.url).to.equal(variables.url);
       expect(data.isFavorite).is.false;
       expect(data.isArchived).is.false;
@@ -475,7 +470,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(permLibQueueBody.timeAdded).equals('2021-10-06 03:22:00');
       expect(permLibQueueBody.resolvedId).equals(25);
     });
-    describe.skip(' - on existing savedItem: ', () => {
+    describe(' - on existing savedItem: ', () => {
       const ADD_AN_ITEM = `
         mutation addAnItem(
           $url: String!
@@ -654,7 +649,7 @@ describe('UpsertSavedItem Mutation', () => {
       });
     });
   });
-  describe.skip('sad path', function () {
+  describe('sad path', function () {
     it('should return error for invalid url', async () => {
       mockParserGetItemRequest('abcde1234', {
         item: {

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -194,7 +194,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.favoritedAt).is.null;
     });
 
-    it.only('should return user provided title on the returned savedItem', async () => {
+    it('should return user provided title on the returned savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',
         title: 'test-user-title',
@@ -214,7 +214,7 @@ describe('UpsertSavedItem Mutation', () => {
       });
       expect(mutationResult).is.not.null;
       const data = mutationResult.body.data?.upsertSavedItem;
-      expect(data.title).to.equal('bob');
+      expect(data.title).to.equal(variables.title);
     });
 
     it('should add an item to the list even if the parser has not yet resolved or cannot resolve it', async () => {
@@ -471,7 +471,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(permLibQueueBody.timeAdded).equals('2021-10-06 03:22:00');
       expect(permLibQueueBody.resolvedId).equals(25);
     });
-    describe.skip(' - on existing savedItem: ', () => {
+    describe(' - on existing savedItem: ', () => {
       const ADD_AN_ITEM = `
         mutation addAnItem(
           $url: String!
@@ -650,7 +650,7 @@ describe('UpsertSavedItem Mutation', () => {
       });
     });
   });
-  describe.skip('sad path', function () {
+  describe('sad path', function () {
     it('should return error for invalid url', async () => {
       mockParserGetItemRequest('abcde1234', {
         item: {

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -214,7 +214,7 @@ describe('UpsertSavedItem Mutation', () => {
       });
       expect(mutationResult).is.not.null;
       const data = mutationResult.body.data?.upsertSavedItem;
-      expect(data.title).to.equal(variables.title);
+      expect(data.title).to.equal('bob');
     });
 
     it('should add an item to the list even if the parser has not yet resolved or cannot resolve it', async () => {

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -148,7 +148,7 @@ describe('UpsertSavedItem Mutation', () => {
       );
     });
 
-    it.skip('should add a valid item and return savedItem', async () => {
+    it.only('should add a valid item and return savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',
       };
@@ -198,7 +198,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.favoritedAt).is.null;
     });
 
-    it.only('should return user provided title on the returned savedItem', async () => {
+    it.skip('should return user provided title on the returned savedItem', async () => {
       const variables = {
         url: 'http://testing-title.com',
         title: 'test-user-title',

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -131,6 +131,10 @@ describe('UpsertSavedItem Mutation', () => {
           url: 'http://write-client.com',
           itemId: 50,
         },
+        {
+          url: 'http://testing-title.com',
+          itemId: 19,
+        },
       ];
       mockRequestData.forEach(({ url, itemId }) =>
         mockParserGetItemRequest(url, {
@@ -196,7 +200,7 @@ describe('UpsertSavedItem Mutation', () => {
 
     it.only('should return user provided title on the returned savedItem', async () => {
       const variables = {
-        url: 'http://getpocket.com',
+        url: 'http://testing-title.com',
         title: 'test-user-title',
       };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,7 @@ export type PendingItem = {
 export type SavedItem = RemoteEntity & {
   resolvedId: string;
   url: string;
+  title?: string;
   isFavorite: boolean;
   status: keyof typeof SavedItemStatus;
   favoritedAt?: number;
@@ -125,6 +126,7 @@ export type SavedItemUpsertInput = {
   url: string;
   isFavorite?: boolean;
   timestamp?: number;
+  title?: string;
 };
 
 /**


### PR DESCRIPTION
## Goal
Adding support for the `title` field for the `upsertSavedItem` mutation.

We can now provide `title` as part of the mutation input. If provided in the input it will be saved and returned. 
If not provided as part of the mutation input, will be set to what the parser call returns and saved as that.

Jira ticket:
* https://getpocket.atlassian.net/browse/INFRA-1195
