### PR TITLE
bug(schema.graphql): re-add schema.graphql file to workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
           name: Setup workspace
           command: |
             mkdir -p /tmp/workspace/app_prod
-            cp -r ./node_modules package.json Dockerfile ./dist /tmp/workspace/app_prod
+            cp -r ./node_modules package.json Dockerfile ./dist schema.graphql /tmp/workspace/app_prod
       # Persist built files to workspace
       - persist_to_workspace:
           root: /tmp/workspace


### PR DESCRIPTION
This is so it can be picked up for Docker image build and thus be in runtime dir so the server will start (because of /src/server/typeDefs.ts).

Fixes bug introduced by #717 