### PR TITLE
feat(ci): circleci slack notification on failed job steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,9 @@ jobs:
           root: /tmp/workspace
           paths:
             - app_prod
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
 
   test_integrations:
     description: Run integration tests against external services, e.g. MySQL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ orbs:
   backstage-entity-validator: roadiehq/backstage-entity-validator@0.4.2
   path-filtering: circleci/path-filtering@0.1.4
   continuation: circleci/continuation@0.3.1
+  slack: circleci/slack@4.1
 
 # Workflow shortcuts
 not_main: &not_main
@@ -53,6 +54,14 @@ only_dev: &only_dev
     branches:
       only:
         - dev
+
+# Use for notifying failure of step
+slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - slack/notify:
+        branch_pattern: main
+        event: fail
+        template: basic_fail_1
 
 jobs:
   apollo:
@@ -205,6 +214,7 @@ workflows:
       - continuation/continue:
           configuration_path: .circleci/continue-config.yml
           parameters: '{"run-build-deploy-events-lambda-job":true}'
+          <<: *slack-fail-post-step
       - test_specs:
           <<: *not_main
           context: pocket
@@ -217,10 +227,12 @@ workflows:
 
       - build:
           context: pocket
+          <<: *slack-fail-post-step
 
       - apollo:
           requires:
             - build
+          <<: *slack-fail-post-step
 
       # Try building the ECS docker image on each branch
       - pocket/docker_build:
@@ -270,6 +282,7 @@ workflows:
       # Build & Deploy the Prod Docker Image
       - pocket/docker_build:
           <<: *only_main
+          <<: *slack-fail-post-step
           context: pocket
           name: build_docker_prod
           aws-access-key-id: Prod_AWS_ACCESS_KEY
@@ -286,6 +299,7 @@ workflows:
       # Prod
       - pocket/execute_codepipeline:
           <<: *only_main
+          <<: *slack-fail-post-step
           context: pocket
           name: deploy_prod
           environment: Prod
@@ -301,6 +315,7 @@ workflows:
       # Prod
       - pocket/setup_deploy_params:
           <<: *only_main
+          <<: *slack-fail-post-step
           name: setup-deploy-params-prod
           aws_access_key_id: Prod_AWS_ACCESS_KEY
           aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
@@ -426,6 +441,7 @@ workflows:
       # Build & Deploy the Prod Docker Image
       - pocket/docker_build:
           <<: *only_main
+          <<: *slack-fail-post-step
           context: pocket
           name: build_docker_prod
           aws-access-key-id: Prod_AWS_ACCESS_KEY
@@ -442,6 +458,7 @@ workflows:
       # Prod
       - pocket/execute_codepipeline:
           <<: *only_main
+          <<: *slack-fail-post-step
           context: pocket
           name: deploy_prod
           environment: Prod
@@ -457,6 +474,7 @@ workflows:
       # Prod
       - pocket/setup_deploy_params:
           <<: *only_main
+          <<: *slack-fail-post-step
           name: setup-deploy-params-prod
           aws_access_key_id: Prod_AWS_ACCESS_KEY
           aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,9 +131,6 @@ jobs:
           root: /tmp/workspace
           paths:
             - app_prod
-      - slack/notify:
-          event: pass
-          template: success_tagged_deploy_1
 
   test_integrations:
     description: Run integration tests against external services, e.g. MySQL

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -5,6 +5,7 @@ setup: false
 orbs:
   pocket: pocket/circleci-orbs@1.2.7
   aws-cli: circleci/aws-cli@1.2.1
+  slack: circleci/slack@4.1
 
 # the default pipeline parameters, which will be updated according to
 # the results of the path-filtering orb
@@ -36,7 +37,13 @@ only_dev: &only_dev
     branches:
       only:
         - dev
-
+# Use for notifying failure of step
+slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - slack/notify:
+        branch_pattern: main
+        event: fail
+        template: basic_fail_1
 
 jobs:
   lambda:
@@ -173,6 +180,7 @@ workflows:
       # Build & Deploy Production Lambdas
       - lambda:
           <<: *only_main
+          <<: *slack-fail-post-step
           context: pocket
           name: deploy_lambda_events_prod
           env_lower_name: prod


### PR DESCRIPTION
## Goal

Add job step failure notifications. Uses post-steps in circleci to notify on failure of any step. Since the branch filtering is applied to main only, I didn't apply to any steps not run on main.

Tested on previous (reverted) commit using build pass notification to ensure that the integration was properly set up. 

## I'd love feedback/perspectives on:
- any

## Implementation Decisions
- use post-steps to hook into each workflow job

Documentation:
* [Project doc](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2950857054/Circleci+Slack+Deployment+Notifications)
