### PR TITLE
chore(account-deletion): remove user-events subscription (for account-deletion)

### DIFF
--- a/.aws/src/lambda/EventLambda.ts
+++ b/.aws/src/lambda/EventLambda.ts
@@ -1,8 +1,5 @@
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
-import { ApplicationSqsSnsTopicSubscription } from '@pocket-tools/terraform-modules';
 import { Construct } from 'constructs';
 import { SqsLambda, SqsLambdaProps } from './base/SqsLambda';
-import { config as stackConfig } from '../config';
 
 export class EventLambda extends Construct {
   constructor(

--- a/.aws/src/lambda/EventLambda.ts
+++ b/.aws/src/lambda/EventLambda.ts
@@ -12,22 +12,9 @@ export class EventLambda extends Construct {
   ) {
     super(scope, name.toLowerCase());
 
-    const sqsLambda = new SqsLambda(this, 'Sqs-Event-Consumer', {
+    new SqsLambda(this, 'Sqs-Event-Consumer', {
       vpc: config.vpc,
       batchSize: 10,
     });
-    const lambda = sqsLambda.lambda;
-
-    new ApplicationSqsSnsTopicSubscription(
-      this,
-      'user-events-sns-subscription',
-      {
-        name: stackConfig.prefix,
-        snsTopicArn: `arn:aws:sns:${config.vpc.region}:${config.vpc.accountId}:${stackConfig.lambda.snsTopicName.userEvents}`,
-        sqsQueue: lambda.sqsQueueResource,
-        tags: stackConfig.tags,
-        dependsOn: [lambda.sqsQueueResource as SqsQueue],
-      }
-    );
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim@sha256:203cf4c2b8f4d912cac0e101fea531a5aae0116f42928da28f3cc9bd8e50817c
+FROM node:16-bullseye-slim@sha256:7ee0b958bd5f47f54b58f2b9932b1975a4d98d8f332bd2134c2b65514cadb6c6
 WORKDIR /usr/src/app
 
 ARG GIT_SHA


### PR DESCRIPTION
## Goal

**this is part 1:**
with i-os going live and there is a possibility of ECS task auto-scaling, we don't want our background process account-deletion to scale up with ECS

so we are moving account deletion from this repo to account-data-deleter: https://github.com/Pocket/account-data-deleter/pull/354


### Implementation decision:
- removed the subscription for `user-events`. this would make sure the account-deletion pipeline will not process any user-events from event-bridge

####  dev deployment
`  # aws_sns_topic_subscription.listapi_sqseventconsumer_usereventssnssubscription_0ADA249B will be destroyed`
`  # aws_sqs_queue.listapi_sqseventconsumer_usereventssnssubscription_snstopicdql_333CF5B8 will be destroyed`
`  # aws_sqs_queue_policy.listapi_sqseventconsumer_usereventssnssubscription_snsdlqpolicy_9D972253 will be destroyed`
`  # aws_sqs_queue_policy.listapi_sqseventconsumer_usereventssnssubscription_snssqspolicy_8C5876B4 will be destroyed`

[code build](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/410318598490/projects/ListAPI-Dev/build/ListAPI-Dev%3Af10b3767-ffe7-497b-a7a9-e60197fdcac8/?region=us-east-1)

### follow-ups: 
- once this is successfully tested, in part 2: we can fully tear-down the infrastructure and circleCI setups for account-deletion in this repo
