### PR TITLE
fix(observability): Quick Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@apollo/server": "4.3.0",
+        "@apollo/server": "4.7.1",
         "@apollo/server-plugin-landing-page-graphql-playground": "4.0.0",
         "@apollo/subgraph": "2.3.2",
         "@aws-sdk/client-eventbridge": "3.92.0",
@@ -30,7 +30,7 @@
         "@opentelemetry/sdk-node": "0.34.0",
         "@opentelemetry/sdk-trace-node": "1.8.0",
         "@pocket-tools/apollo-cursor-pagination": "1.0.3",
-        "@pocket-tools/apollo-utils": "3.2.0",
+        "@pocket-tools/apollo-utils": "3.3.1",
         "@pocket-tools/backend-benchmarking": "1.1.0",
         "@sentry/node": "7.8.1",
         "@sentry/tracing": "7.8.1",
@@ -140,13 +140,13 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.3.0.tgz",
-      "integrity": "sha512-M30z/hExJtvqGE4UFJTa0W7FoRPPXmEjrrHK16+v63hE+deH1gYiXq0MdXKvMdoQhQQqnv09jo9mDDEpMBJvjg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.7.1.tgz",
+      "integrity": "sha512-rFxd8jsMlqEYzmhuxATaDAPoRH905R56FKP4TnZWaiDYJtjhHe3hxZOWl24V7s0dB52DIp6S/x+zjQX8fwD37w==",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/server-gateway-interface": "^1.0.7",
-        "@apollo/usage-reporting-protobuf": "^4.0.0",
+        "@apollo/server-gateway-interface": "^1.1.0",
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
         "@apollo/utils.createhash": "^2.0.0",
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.isnodelike": "^2.0.0",
@@ -166,7 +166,7 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^7.10.1",
         "negotiator": "^0.6.3",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "^3.1.1",
         "node-fetch": "^2.6.7",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -284,11 +284,11 @@
       }
     },
     "node_modules/@apollo/utils.keyvaluecache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
-      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz",
+      "integrity": "sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==",
       "dependencies": {
-        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.logger": "^2.0.1",
         "lru-cache": "^7.14.1"
       },
       "engines": {
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
       "engines": {
         "node": ">=14"
       }
@@ -5151,13 +5151,13 @@
       "integrity": "sha512-6EHr3dmF55FQZ0i9IwiSK+8dREfSRdc9tMon7brXCwOQo44znwOQWMgu7066rewq+lzNNUgsQf+UBG3po6DKtA=="
     },
     "node_modules/@pocket-tools/apollo-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/apollo-utils/-/apollo-utils-3.2.0.tgz",
-      "integrity": "sha512-g4e9YZUJGFnUgTgUkYxPjcEK9PAM8oRg8aEk+7krQx++JZAXh1KHqT+azVy8nbTnFuwyCB720ouGxD1AOldvSw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/apollo-utils/-/apollo-utils-3.3.1.tgz",
+      "integrity": "sha512-8qTvyTPKfLtkzMrJVbKU+qyBo2teHM3JXoZ1GY+Si2feMTrfPCrhFr8sjXxiaDQVTs3XAv7CTM4xgnklO0n9mw==",
       "dependencies": {
         "@apollo/server": "^4.2.2",
         "@apollo/subgraph": "^2.2.2",
-        "@apollo/utils.keyvaluecache": "2.1.0",
+        "@apollo/utils.keyvaluecache": "2.1.1",
         "@jest/globals": "29.3.1",
         "@sentry/node": "^7.26.0",
         "deep-equal-in-any-order": "^1.1.13",
@@ -14792,13 +14792,13 @@
       }
     },
     "@apollo/server": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.3.0.tgz",
-      "integrity": "sha512-M30z/hExJtvqGE4UFJTa0W7FoRPPXmEjrrHK16+v63hE+deH1gYiXq0MdXKvMdoQhQQqnv09jo9mDDEpMBJvjg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.7.1.tgz",
+      "integrity": "sha512-rFxd8jsMlqEYzmhuxATaDAPoRH905R56FKP4TnZWaiDYJtjhHe3hxZOWl24V7s0dB52DIp6S/x+zjQX8fwD37w==",
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/server-gateway-interface": "^1.0.7",
-        "@apollo/usage-reporting-protobuf": "^4.0.0",
+        "@apollo/server-gateway-interface": "^1.1.0",
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
         "@apollo/utils.createhash": "^2.0.0",
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.isnodelike": "^2.0.0",
@@ -14818,7 +14818,7 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^7.10.1",
         "negotiator": "^0.6.3",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "^3.1.1",
         "node-fetch": "^2.6.7",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -14897,18 +14897,18 @@
       "integrity": "sha512-77CiAM2qDXn0haQYrgX0UgrboQykb+bOHaz5p3KKItMwUZ/EFphzuB2vqHvubneIc9dxJcTx2L7MFDswRw/JAQ=="
     },
     "@apollo/utils.keyvaluecache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
-      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz",
+      "integrity": "sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==",
       "requires": {
-        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.logger": "^2.0.1",
         "lru-cache": "^7.14.1"
       }
     },
     "@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg=="
     },
     "@apollo/utils.printwithreducedwhitespace": {
       "version": "2.0.0",
@@ -18702,13 +18702,13 @@
       "integrity": "sha512-6EHr3dmF55FQZ0i9IwiSK+8dREfSRdc9tMon7brXCwOQo44znwOQWMgu7066rewq+lzNNUgsQf+UBG3po6DKtA=="
     },
     "@pocket-tools/apollo-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/apollo-utils/-/apollo-utils-3.2.0.tgz",
-      "integrity": "sha512-g4e9YZUJGFnUgTgUkYxPjcEK9PAM8oRg8aEk+7krQx++JZAXh1KHqT+azVy8nbTnFuwyCB720ouGxD1AOldvSw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/apollo-utils/-/apollo-utils-3.3.1.tgz",
+      "integrity": "sha512-8qTvyTPKfLtkzMrJVbKU+qyBo2teHM3JXoZ1GY+Si2feMTrfPCrhFr8sjXxiaDQVTs3XAv7CTM4xgnklO0n9mw==",
       "requires": {
         "@apollo/server": "^4.2.2",
         "@apollo/subgraph": "^2.2.2",
-        "@apollo/utils.keyvaluecache": "2.1.0",
+        "@apollo/utils.keyvaluecache": "2.1.1",
         "@jest/globals": "29.3.1",
         "@sentry/node": "^7.26.0",
         "deep-equal-in-any-order": "^1.1.13",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint-fix": "eslint --fix \"src/**/*.ts\""
   },
   "dependencies": {
-    "@apollo/server": "4.3.0",
+    "@apollo/server": "4.7.1",
     "@apollo/server-plugin-landing-page-graphql-playground": "4.0.0",
     "@apollo/subgraph": "2.3.2",
     "@aws-sdk/client-eventbridge": "3.92.0",
@@ -38,7 +38,7 @@
     "@opentelemetry/sdk-node": "0.34.0",
     "@opentelemetry/sdk-trace-node": "1.8.0",
     "@pocket-tools/apollo-cursor-pagination": "1.0.3",
-    "@pocket-tools/apollo-utils": "3.2.0",
+    "@pocket-tools/apollo-utils": "3.3.1",
     "@pocket-tools/backend-benchmarking": "1.1.0",
     "@sentry/node": "7.8.1",
     "@sentry/tracing": "7.8.1",

--- a/src/server/apollo.ts
+++ b/src/server/apollo.ts
@@ -115,29 +115,15 @@ export async function startServer(port: number) {
     production: [
       ApolloServerPluginLandingPageDisabled(),
       ApolloServerPluginInlineTrace({
-        includeErrors: {
-          transform: (err) => {
-            const userErrorCodes = [
-              'UNAUTHENTICATED',
-              'BAD_USER_INPUT',
-              'NOT_FOUND',
-            ];
-            // JS doesn't like using includes/indexOf methods with unknown,
-            // but equality check is ok
-            const isUserError = (code: string) => code === err.extensions.code;
-            // Return `null` to avoid reporting user-driven errors
-            if (userErrorCodes.some(isUserError)) {
-              return null;
-            }
-            // All other errors will be reported.
-            return err;
-          },
-        },
+        includeErrors: { unmodified: true },
       }),
     ],
   };
 
-  const plugins = [...defaultPlugins, ...pluginsConfig[process.env.NODE_ENV]];
+  const plugins = [
+    ...defaultPlugins,
+    ...(pluginsConfig[process.env.NODE_ENV] ?? []),
+  ];
 
   const server = new ApolloServer<ContextManager>({
     schema,


### PR DESCRIPTION
## Goal
This PR includes two quick fixes. The first leverages work already done (just updates the apollo-utils package version so it gets used). The second change was a recommendation that came out of an incident retro due to Apollo changing their default masking behavior. 

 - Bump apollo-utils package version to automatically tag Sentry errors with x-graph-request-id header
passed from gateway.
- Disable masking from Apollo Studio inline trace reporting; send all errors unmodified to dev, and ~do not send common user-driven errors to prod (UNAUTHENTICATED, NOT_FOUND, BAD_USER_INPUT~) _edit: send all errors to prod for now._

Ticket: [IN-1467]


This change has been deployed to dev successfully, and the apollo engine is healthy (confirmed with some trivial manual queries).

[IN-1467]: https://getpocket.atlassian.net/browse/IN-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ