### PR TITLE
feat(tags): enable tagging by givenUrl

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -456,6 +456,14 @@ input SavedItemTagsInput {
 }
 
 """
+Input field for adding Tag Associations to a SavedItem, by givenUrl
+"""
+input SavedItemTagInput {
+  givenUrl: Url!
+  tagNames: [String!]! @constraint(minItems: 1, maxItems: 30)
+}
+
+"""
 Input field for creating a Tag
 """
 input TagCreateInput {
@@ -758,6 +766,11 @@ type Mutation {
     input: [SaveUpsertInput!]!  @constraint(minItems: 1, maxItems: 30),
     timestamp: ISOString!
   ): SaveWriteMutationPayload! @tag(name: "alpha")
+
+  """
+  Associate Tag(s) with a Save
+  """
+  savedItemTag(input: SavedItemTagInput!, timestamp: ISOString!): SavedItem
 }
 
 # """

--- a/src/dataService/tagDataService.ts
+++ b/src/dataService/tagDataService.ts
@@ -208,10 +208,14 @@ export class TagDataService {
    * is actually in the user's list (no foreign key constraint).
    * @param tagInputs
    */
-  public async insertTags(tagInputs: TagSaveAssociation[]): Promise<void> {
+  public async insertTags(
+    tagInputs: TagSaveAssociation[],
+    timestamp?: Date
+  ): Promise<void> {
+    const updatedTime = timestamp ?? new Date();
     await this.db.transaction(async (trx: Knex.Transaction) => {
-      await this.insertTagAndUpdateSavedItem(tagInputs, trx);
-      await this.usersMetaService.logTagMutation(new Date(), trx);
+      await this.insertTagAndUpdateSavedItem(tagInputs, trx, updatedTime);
+      await this.usersMetaService.logTagMutation(updatedTime, trx);
     });
   }
 

--- a/src/externalCaller/parserCaller.spec.ts
+++ b/src/externalCaller/parserCaller.spec.ts
@@ -3,20 +3,17 @@ import chaiAsPromised from 'chai-as-promised';
 import { ParserCaller } from './parserCaller';
 import nock from 'nock';
 import config from '../config';
+import {
+  mockParserGetItemRequest,
+  mockParserGetItemIdRequest,
+} from '../test/utils/parserMocks';
 
 chai.use(chaiAsPromised);
-
-function mockParserGetItemRequest(urlToParse: string, data: any) {
-  nock(config.parserDomain)
-    .get(`/${config.parserVersion}/getItemListApi`)
-    .query({ url: urlToParse, getItem: '1' })
-    .reply(200, data);
-}
 
 describe('ParserCallerTest', function () {
   const urlToParse = 'https://igiveyou.a.test';
 
-  it('should retrieve item id from parser service', async () => {
+  it('should retrieve item from parser service', async () => {
     mockParserGetItemRequest(urlToParse, {
       item: {
         given_url: urlToParse,
@@ -92,5 +89,15 @@ describe('ParserCallerTest', function () {
     expect(res.itemId).equals(8);
     expect(res.title).equals('The Not Evil Search Engine');
     expect(res.resolvedId).equals(9);
+  });
+  it('should retrieve item id from parser service', async () => {
+    mockParserGetItemIdRequest(urlToParse, '22');
+    const itemId = await ParserCaller.getItemIdFromUrl(urlToParse);
+    expect(itemId).equals('22');
+  });
+  it('should return null if item does not exist', async () => {
+    mockParserGetItemIdRequest(urlToParse, null);
+    const itemId = await ParserCaller.getItemIdFromUrl(urlToParse);
+    expect(itemId).to.be.null;
   });
 });

--- a/src/externalCaller/parserCaller.ts
+++ b/src/externalCaller/parserCaller.ts
@@ -72,7 +72,8 @@ export class ParserCaller {
 
   /**
    * Get the Parser-generated itemId for a given url.
-   * TODO: stop using this method once given_url is indexed in the list table
+   * TODO[IN-1478]: stop using this method once given_url is indexed in the list table
+   * https://getpocket.atlassian.net/browse/IN-1478
    * @param url the URL of the Save you want an itemId for
    * @param tries # of request retries if there are issues with the Parser service
    * @returns the itemId for the given url, or null if it does not exist
@@ -87,7 +88,8 @@ export class ParserCaller {
 
   /**
    * Get the Parser-generated itemId for a given url.
-   * TODO: stop using this method once given_url is indexed in the list table
+   * TODO[IN-1478]: Stop using this method once given_url is indexed in the list table
+   * https://getpocket.atlassian.net/browse/IN-1478
    * @param url the URL of the Save you want an itemId for
    * @returns the itemId for the given url
    * @throws Error if item does not exist

--- a/src/externalCaller/parserCaller.ts
+++ b/src/externalCaller/parserCaller.ts
@@ -1,5 +1,13 @@
 import fetch from 'node-fetch';
 import config from '../config';
+import { setTimeout } from 'timers/promises';
+
+export type PartialGetItemResponse = {
+  // This is modeling a subset of the response
+  // for the Parser's getItem endpoint; right now
+  // we only are using item_id
+  item_id: string;
+};
 
 export type ItemResponse = {
   itemId: string;
@@ -40,16 +48,58 @@ export class ParserCaller {
     url: string,
     tries = config.parserRetries
   ): Promise<ItemResponse> {
+    const requestCallback = () => this.internalGetOrCreateItem(url);
+    return this.sendRequest(requestCallback, tries);
+  }
+
+  private static async sendRequest<R>(
+    requestCallback: () => Promise<R>,
+    tries = config.parserRetries
+  ): Promise<R> {
     let lastError = null;
     while (tries > 0) {
       try {
-        return await this.internalGetOrCreateItem(url);
+        return await requestCallback();
       } catch (e) {
         lastError = e;
       }
+      await setTimeout(500);
       tries--;
     }
 
     throw lastError;
+  }
+
+  /**
+   * Get the Parser-generated itemId for a given url.
+   * TODO: stop using this method once given_url is indexed in the list table
+   * @param url the URL of the Save you want an itemId for
+   * @param tries # of request retries if there are issues with the Parser service
+   * @returns the itemId for the given url, or null if it does not exist
+   */
+  public static async getItemIdFromUrl(
+    url: string,
+    tries = config.parserRetries
+  ): Promise<string | null> {
+    const requestCallback = () => this.internalGetItemIdFromUrl(url);
+    return this.sendRequest(requestCallback, tries);
+  }
+
+  /**
+   * Get the Parser-generated itemId for a given url.
+   * TODO: stop using this method once given_url is indexed in the list table
+   * @param url the URL of the Save you want an itemId for
+   * @returns the itemId for the given url
+   * @throws Error if item does not exist
+   */
+  public static async internalGetItemIdFromUrl(url: string): Promise<string> {
+    const response = await fetch(
+      `${config.parserDomain}/${
+        config.parserVersion
+      }/getItem?url=${encodeURIComponent(url)}&createIfNone=false`
+    );
+
+    const data: PartialGetItemResponse | null = await response.json();
+    return data?.item_id ?? null;
   }
 }

--- a/src/models/tag.ts
+++ b/src/models/tag.ts
@@ -109,6 +109,9 @@ export class TagModel {
     timestamp: Date
   ): Promise<SavedItem> {
     const { givenUrl, tagNames } = input;
+    // TODO[IN-1478]: Remove this lookup once givenUrl is indexed
+    // in the list table (replace with direct db update by givenUrl)
+    // https://getpocket.atlassian.net/browse/IN-1478
     const savedItemId = await ParserCaller.getItemIdFromUrl(givenUrl);
     if (savedItemId == null) {
       throw new NotFoundError(

--- a/src/models/tag.ts
+++ b/src/models/tag.ts
@@ -22,6 +22,7 @@ import { addslashes } from 'locutus/php/strings';
 import * as Sentry from '@sentry/node';
 import { GraphQLResolveInfo } from 'graphql';
 import { ParserCaller } from '../externalCaller/parserCaller';
+import { EventType } from '../businessEvents';
 
 export class TagModel {
   private tagService: TagDataService;
@@ -121,7 +122,10 @@ export class TagModel {
       }))
     );
     await this.tagService.insertTags(creates, timestamp);
-    return this.saveService.getSavedItemById(savedItemId);
+    const savedItem = await this.saveService.getSavedItemById(savedItemId);
+    // Emit events
+    this.context.emitItemEvent(EventType.ADD_TAGS, savedItem, tagNames);
+    return savedItem;
   }
 
   /**

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -28,6 +28,7 @@ import {
   SaveUpdateTagsInputGraphql,
   SaveWriteMutationPayload,
   SavedItem,
+  SavedItemTagInput,
   Tag,
 } from '../types';
 import { IContext } from '../server/context';
@@ -199,6 +200,16 @@ const resolvers = {
     ): null => {
       //TODO @Herraj --> implementation in a follow up PR
       return null;
+    },
+    savedItemTag: async (
+      _,
+      args: { input: SavedItemTagInput; timestamp: Date },
+      context: IContext
+    ): Promise<SavedItem | null> => {
+      return await context.models.tag.createSavedItemTagConnections(
+        args.input,
+        args.timestamp
+      );
     },
   },
 };

--- a/src/test/graphql/mutations/savedItemTag.integration.ts
+++ b/src/test/graphql/mutations/savedItemTag.integration.ts
@@ -1,0 +1,265 @@
+import { ApolloServer } from '@apollo/server';
+import { ContextManager } from '../../../server/context';
+import { readClient } from '../../../database/client';
+import { startServer } from '../../../server/apollo';
+import { Express } from 'express';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+import { mockParserGetItemIdRequest } from '../../utils/parserMocks';
+
+describe('savedItemTag mutation', () => {
+  const db = readClient();
+  const headers = { userid: '1' };
+  const date = new Date('2020-10-03T10:20:30.000Z');
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const SAVEDITEM_TAGS_CREATE = gql`
+    mutation saveBatchUpdateTags(
+      $input: SavedItemTagInput!
+      $timestamp: ISOString!
+    ) {
+      savedItemTag(input: $input, timestamp: $timestamp) {
+        url
+        _updatedAt
+        tags {
+          name
+        }
+      }
+    }
+  `;
+
+  const GET_TAGS_FOR_SAVEDITEM = gql`
+    query getTagsSavedItem($userId: ID!, $itemId: ID!) {
+      _entities(representations: { id: $userId, __typename: "User" }) {
+        ... on User {
+          savedItemById(id: $itemId) {
+            ... on PocketSave {
+              tags {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+  });
+  beforeEach(async () => {
+    await db('list').truncate();
+    await db('item_tags').truncate();
+    const listDataBase = {
+      user_id: 1,
+      title: 'mytitle',
+      time_added: date,
+      time_updated: date,
+      time_read: date,
+      time_favorited: date,
+      api_id: 'apiid',
+      status: 0,
+      favorite: 0,
+      api_id_updated: 'apiid',
+    };
+    const tagsDataBase = {
+      user_id: 1,
+      status: 1,
+      time_added: date,
+      time_updated: date,
+      api_id: 'apiid',
+      api_id_updated: 'apiid',
+    };
+    await db('list').insert([
+      {
+        ...listDataBase,
+        item_id: 1,
+        resolved_id: 1,
+        given_url: 'http://abc',
+      },
+      {
+        ...listDataBase,
+        item_id: 2,
+        resolved_id: 2,
+        given_url: 'http://def',
+      },
+    ]);
+    await db('item_tags').insert([
+      {
+        ...tagsDataBase,
+        item_id: 1,
+        tag: 'tobio',
+      },
+      {
+        ...tagsDataBase,
+        item_id: 1,
+        tag: 'shoyo',
+      },
+    ]);
+  });
+  afterAll(async () => {
+    await db.destroy();
+    await server.stop();
+  });
+  it('should add tags to a SavedItem with no tags', async () => {
+    const givenUrl = 'http://def';
+    mockParserGetItemIdRequest(givenUrl, '2');
+    const timestamp = '2023-05-12T10:58:00.000Z';
+    const variables = {
+      input: {
+        givenUrl,
+        tagNames: ['sugawara', 'daiichi'],
+      },
+      timestamp,
+    };
+    const expected = {
+      savedItemTag: {
+        url: givenUrl,
+        _updatedAt: Math.round(new Date(timestamp).getTime() / 1000),
+        tags: expect.toIncludeSameMembers([
+          { name: 'sugawara' },
+          { name: 'daiichi' },
+        ]),
+      },
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(SAVEDITEM_TAGS_CREATE),
+        variables,
+      });
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data).toStrictEqual(expected);
+  });
+  it('should add tags to a SavedItem with tags already, preserving old tags', async () => {
+    const givenUrl = 'http://abc';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const timestamp = '2023-05-12T10:58:00.000Z';
+    const variables = {
+      input: {
+        givenUrl,
+        tagNames: ['sugawara', 'daiichi'],
+      },
+      timestamp,
+    };
+    const expected = {
+      savedItemTag: {
+        url: givenUrl,
+        _updatedAt: Math.round(new Date(timestamp).getTime() / 1000),
+        tags: expect.toIncludeSameMembers([
+          { name: 'sugawara' },
+          { name: 'daiichi' },
+          { name: 'shoyo' },
+          { name: 'tobio' },
+        ]),
+      },
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(SAVEDITEM_TAGS_CREATE),
+        variables,
+      });
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data).toStrictEqual(expected);
+  });
+  it('should not throw an error if the tag already exists, and not duplicate', async () => {
+    const givenUrl = 'http://abc';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const timestamp = '2023-05-12T10:58:00.000Z';
+    const variables = {
+      input: {
+        givenUrl,
+        tagNames: ['shoyo'],
+      },
+      timestamp,
+    };
+    const expected = {
+      savedItemTag: {
+        url: givenUrl,
+        _updatedAt: Math.round(new Date(timestamp).getTime() / 1000),
+        tags: expect.toIncludeSameMembers([
+          { name: 'shoyo' },
+          { name: 'tobio' },
+        ]),
+      },
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(SAVEDITEM_TAGS_CREATE),
+        variables,
+      });
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data).toStrictEqual(expected);
+  });
+  it('should add new tags even if passed a tag that already exists', async () => {
+    const givenUrl = 'http://abc';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const timestamp = '2023-05-12T10:58:00.000Z';
+    const variables = {
+      input: {
+        givenUrl,
+        tagNames: ['shoyo', 'sugawara'],
+      },
+      timestamp,
+    };
+    const expected = {
+      savedItemTag: {
+        url: givenUrl,
+        _updatedAt: Math.round(new Date(timestamp).getTime() / 1000),
+        tags: expect.toIncludeSameMembers([
+          { name: 'shoyo' },
+          { name: 'tobio' },
+          { name: 'sugawara' },
+        ]),
+      },
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(SAVEDITEM_TAGS_CREATE),
+        variables,
+      });
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data).toStrictEqual(expected);
+  });
+  it('should include NOT_FOUND in errors array if no SavedItem exists with the givenUrl', async () => {
+    const givenUrl = 'http://hij';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const timestamp = '2023-05-12T10:58:00.000Z';
+    const variables = {
+      input: {
+        givenUrl,
+        tagNames: ['shoyo'],
+      },
+      timestamp,
+    };
+    const expectedData = { savedItemTag: null };
+    const expectedError = expect.toIncludeAllMembers([
+      expect.objectContaining({
+        extensions: {
+          code: 'NOT_FOUND',
+        },
+        message: expect.stringContaining(
+          "Not Found: SavedItem with givenUrl='http://hij' does not exist"
+        ),
+      }),
+    ]);
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(SAVEDITEM_TAGS_CREATE),
+        variables,
+      });
+    expect(res.body.errors).toStrictEqual(expectedError);
+    expect(res.body.data).toStrictEqual(expectedData);
+  });
+});

--- a/src/test/utils/parserMocks.ts
+++ b/src/test/utils/parserMocks.ts
@@ -1,0 +1,34 @@
+import nock from 'nock';
+import config from '../../config';
+
+function mockParserRequest(
+  urlToParse: string,
+  data: any,
+  options: { endpoint: string; queryParams: { [key: string]: string } }
+) {
+  nock(config.parserDomain)
+    .get(options.endpoint)
+    .query(options.queryParams)
+    .reply(200, data);
+}
+
+export const mockParserGetItemRequest = (urlToParse: string, data: any) => {
+  return mockParserRequest(urlToParse, data, {
+    endpoint: `/${config.parserVersion}/getItemListApi`,
+    queryParams: { url: urlToParse, getItem: '1' },
+  });
+};
+
+export const mockParserGetItemIdRequest = (
+  urlToParse: string,
+  itemId: string | null
+) => {
+  return mockParserRequest(
+    urlToParse,
+    itemId != null ? { item_id: itemId } : null,
+    {
+      endpoint: `/${config.parserVersion}/getItem`,
+      queryParams: { url: urlToParse, createIfNone: 'false' },
+    }
+  );
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,6 +164,11 @@ export type SavedItemTagsInput = {
   tags: string[];
 };
 
+export type SavedItemTagInput = {
+  givenUrl: string;
+  tagNames: string[];
+};
+
 export type TagUpdateInput = {
   name: string;
   id: string;


### PR DESCRIPTION
## Goal
Resolve issues with offline mobile clients by enabling tagging by givenUrl. Other mutations/queries will follow. This is because givenUrl is available offline, but a server-provided itemId (which is the key for accessing all saves at this time), is not available for offline clients creating new saves.

- [x] create new mutation for tagging by givenUrl `savedItemTag`
- [x] emit add_tag events on success
- [x] update parser caller to use the getItem endpoint and extract the itemId from response; small refactor for reusing code and test mocks

## I'd love feedback/perspectives on:
- is the parser dependency ok for a short term solution?
- failing with NOT_FOUND if parser does not have an itemId for url (vs. using createIfNone param)

## Implementation Decisions
- Use the parser for resolving itemId instead of replicating the url transformation/hashing logic and looking up in `readitla_b` from list
- alternatively also, use the parser instead of looking up by givenUrl in `list` since givenUrl is not indexed (request has been made to index this field)
- do not create the itemId if it doesn't exist; return NOT_FOUND instead. The itemId should always exist prior to the tag action, and I think there's a risk of having records not connected properly if we use the `createIfNone` method on the parser (potentially the url could have one itemId for the tag records and a different one for the save, depending on some edge conditions). 

## References

Jira ticket:
* [IN-1453]



[IN-1453]: https://getpocket.atlassian.net/browse/IN-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ