### PR TITLE
fix(db): chunk queries to avoid full table scan

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ process.env.AWS_SECRET_ACCESS_KEY = 'fake-key';
 process.env.AWS_DEFAULT_REGION = 'us-east-1';
 process.env.NODE_ENV = 'test';
 process.env.EVENT_BUS_NAME = 'default';
+process.env.MAX_TRX_SIZE = 2;
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "graphql-tag": "2.12.6",
         "knex": "2.4.2",
         "locutus": "2.0.16",
+        "lodash": "4.17.21",
         "luxon": "2.5.2",
         "mysql": "2.18.1",
         "nanoid": "3.3.6"
@@ -60,6 +61,7 @@
         "@types/graphql-upload": "16.0.0",
         "@types/jest": "29.5.0",
         "@types/locutus": "0.0.6",
+        "@types/lodash": "^4.14.194",
         "@types/luxon": "2.4.0",
         "@types/node": "16.11.68",
         "@types/sinon": "10.0.15",
@@ -6976,6 +6978,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/locutus/-/locutus-0.0.6.tgz",
       "integrity": "sha512-P+BQds4wrJhqKiIOBWAYpbsE9UOztnnqW9zHk4Bci7kCXjEQAA7FJrD9HX5JU2Z36fhE2WDctuuIpLvqDsciWQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
       "dev": true
     },
     "node_modules/@types/long": {
@@ -20228,6 +20236,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/locutus/-/locutus-0.0.6.tgz",
       "integrity": "sha512-P+BQds4wrJhqKiIOBWAYpbsE9UOztnnqW9zHk4Bci7kCXjEQAA7FJrD9HX5JU2Z36fhE2WDctuuIpLvqDsciWQ==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
       "dev": true
     },
     "@types/long": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "graphql-tag": "2.12.6",
     "knex": "2.4.2",
     "locutus": "2.0.16",
+    "lodash": "4.17.21",
     "luxon": "2.5.2",
     "mysql": "2.18.1",
     "nanoid": "3.3.6"
@@ -68,6 +69,7 @@
     "@types/graphql-upload": "16.0.0",
     "@types/jest": "29.5.0",
     "@types/locutus": "0.0.6",
+    "@types/lodash": "^4.14.194",
     "@types/luxon": "2.4.0",
     "@types/node": "16.11.68",
     "@types/sinon": "10.0.15",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -96,6 +96,7 @@ export default {
     },
     dbName: process.env.DATABASE || 'readitla_ril-tmp',
     tz: process.env.DATABASE_TZ || 'US/Central',
+    maxTransactionSize: parseInt(process.env.MAX_TRX_SIZE) || 1000,
   },
   dataloaderDefaults: {
     // TBD: batchScheduleFn: (callback) => setTimeout(callback, 10) // every 10 ms


### PR DESCRIPTION
If 'where in' array is too large, then
mysql will ignore indices and scan the
entire table. The exact value at which
this happens depends on some memory settings.
Manual testing showed that 10k size will work
(we can tune this with the config value in
the future).

