### PR TITLE
feat(federation): resolve Item by itemId

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -614,9 +614,8 @@ type PendingItem @key(fields: "url") {
   status: PendingItemStatus
 }
 
-type Item @key(fields: "givenUrl") {
+type Item @key(fields: "itemId") {
   "key field to identify the Item entity in the Parser service"
-  givenUrl: Url!
   itemId: String! @shareable
 
   #Note more properties exist here but are defined in another service.

--- a/src/businessEvents/itemsEventEmitter.spec.ts
+++ b/src/businessEvents/itemsEventEmitter.spec.ts
@@ -22,7 +22,6 @@ describe('ItemsEventEmitter', () => {
     status: 'UNREAD',
     isFavorite: true,
     isArchived: false,
-    item: { givenUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
   };
 
   const payload: BasicItemEventPayloadWithContext = {

--- a/src/businessEvents/unifiedEventKinesisHandler.spec.ts
+++ b/src/businessEvents/unifiedEventKinesisHandler.spec.ts
@@ -21,9 +21,6 @@ describe('UnifiedEventHandler', () => {
     isFavorite: true,
     isArchived: false,
     status: 'UNREAD',
-    item: {
-      givenUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-    },
   };
 
   it('should log an error if there are failed messages after retrying', async () => {

--- a/src/dataLoader/savedItemsDataLoader.spec.ts
+++ b/src/dataLoader/savedItemsDataLoader.spec.ts
@@ -16,9 +16,6 @@ describe('savedItem data loader', function () {
       isFavorite: false,
       isArchived: false,
       status: 'UNREAD',
-      item: {
-        givenUrl: 'abc.com',
-      },
     },
     {
       id: '2',
@@ -27,9 +24,6 @@ describe('savedItem data loader', function () {
       isFavorite: false,
       isArchived: false,
       status: 'DELETED',
-      item: {
-        givenUrl: 'def.com',
-      },
     },
   ];
 

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -66,9 +66,9 @@ const resolvers = {
   },
   Item: {
     savedItem: async (item: Item, args, context: IContext) => {
-      return await context.dataLoaders.savedItemsByUrl.load(item.givenUrl);
+      return await context.dataLoaders.savedItemsById.load(item.itemId);
     },
-    // This is basically a passthrough so that the givenUrl is available
+    // This is basically a passthrough so that the itemId is available
     // on the parent when the savedItem entity is resolved
     // Possible to resolve savedItem on this reference resolver instead,
     // but this maintains our pattern of separation of entity resolvers

--- a/src/server/context.spec.ts
+++ b/src/server/context.spec.ts
@@ -18,9 +18,6 @@ describe('context', () => {
     isFavorite: false,
     status: 'UNREAD',
     isArchived: false,
-    item: {
-      givenUrl: 'dont-care.com',
-    },
   };
   describe('constructor', () => {
     const sentryScopeSpy = sinon.spy(Sentry, 'configureScope');

--- a/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
+++ b/src/test/graphql/mutations/savedItemsMutationService-upsert.integration.ts
@@ -165,7 +165,7 @@ describe('UpsertSavedItem Mutation', () => {
             _version
             item {
               ... on Item {
-                givenUrl
+                itemId
               }
             }
             tags {
@@ -188,7 +188,7 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.isArchived).is.false;
       expect(data._deletedAt).is.null;
       expect(data._version).is.null;
-      expect(data.item.givenUrl).equals(variables.url);
+      expect(data.item.itemId).equals('8');
       expect(data.tags[0].name).equals('zebra');
       expect(data.archivedAt).is.null;
       expect(data.favoritedAt).is.null;
@@ -236,7 +236,7 @@ describe('UpsertSavedItem Mutation', () => {
             item {
               ... on Item {
                 __typename
-                givenUrl
+                itemId
               }
               ... on PendingItem {
                 __typename
@@ -255,7 +255,6 @@ describe('UpsertSavedItem Mutation', () => {
       expect(mutationResult).is.not.null;
       const data = mutationResult.body.data?.upsertSavedItem;
       expect(data.id).to.equal('1');
-      expect(data.item.givenUrl).is.undefined;
       expect(data.item.url).to.equal(givenUrl);
       expect(data.item.itemId).to.equal('1');
       expect(data.item.__typename).to.equal('PendingItem');

--- a/src/test/graphql/queries/item.integration.ts
+++ b/src/test/graphql/queries/item.integration.ts
@@ -11,7 +11,7 @@ describe('item', () => {
 
   const itemFragment = `
     fragment ItemFields on Item {
-      givenUrl
+      itemId
       savedItem {
         id
         url
@@ -22,8 +22,8 @@ describe('item', () => {
   `;
   const GET_SAVED_ITEM = `
     ${itemFragment}
-    query getSaveFromItem($givenUrl: String!) {
-      _entities(representations: { givenUrl: $givenUrl, __typename: "Item" }) {
+    query getSaveFromItem($itemId: String!) {
+      _entities(representations: { itemId: $itemId, __typename: "Item" }) {
         ... on Item {
           ...ItemFields
         }
@@ -34,11 +34,11 @@ describe('item', () => {
   // than to just duplicate it
   const GET_TWO_SAVED_ITEMS = `
     ${itemFragment}
-    query getSavesFromItems($givenUrl1: String!, $givenUrl2: String!) {
+    query getSavesFromItems($itemId1: String!, $itemId2: String!) {
       _entities(
         representations: [
-          { givenUrl: $givenUrl1, __typename: "Item" }
-          { givenUrl: $givenUrl2, __typename: "Item" }
+          { itemId: $itemId1, __typename: "Item" }
+          { itemId: $itemId2, __typename: "Item" }
         ]
       ) {
         ... on Item {
@@ -113,7 +113,7 @@ describe('item', () => {
   it('resolves more than one savedItem from multiple entities', async () => {
     const expected = [
       {
-        givenUrl: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+        itemId: '1',
         savedItem: {
           url: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
           isFavorite: true,
@@ -122,7 +122,7 @@ describe('item', () => {
         },
       },
       {
-        givenUrl: 'https://www.youtube.com/watch?v=OZaL86RDGIU',
+        itemId: '999',
         savedItem: {
           url: 'https://www.youtube.com/watch?v=OZaL86RDGIU',
           isFavorite: false,
@@ -133,8 +133,8 @@ describe('item', () => {
     ];
     const variables = {
       userId: '1',
-      givenUrl1: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
-      givenUrl2: 'https://www.youtube.com/watch?v=OZaL86RDGIU',
+      itemId1: '1',
+      itemId2: '999',
     };
 
     const res = await request(app).post(url).set(headers).send({
@@ -149,7 +149,7 @@ describe('item', () => {
   });
   it('resolves savedItem field from entity representation', async () => {
     const expected = {
-      givenUrl: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+      itemId: '1',
       savedItem: {
         url: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
         isFavorite: true,
@@ -159,7 +159,7 @@ describe('item', () => {
     };
     const variables = {
       userId: '1',
-      givenUrl: 'https://www.youtube.com/watch?v=aWJ_7akYFhg',
+      itemId: '1',
     };
 
     const res = await request(app).post(url).set(headers).send({
@@ -176,7 +176,7 @@ describe('item', () => {
   it('returns null if the save does not exist', async () => {
     const variables = {
       userId: '1',
-      givenUrl: 'https://www.youtube.com/watch?v=Tpbo25iBvfU',
+      itemId: '2',
     };
 
     const res = await request(app).post(url).set(headers).send({
@@ -187,9 +187,7 @@ describe('item', () => {
     expect(res.body.errors).toBeUndefined;
     const entities = res.body.data._entities;
     expect(entities.length).toEqual(1);
-    expect(entities[0].givenUrl).toEqual(
-      'https://www.youtube.com/watch?v=Tpbo25iBvfU'
-    );
+    expect(entities[0].itemId).toEqual('2');
     expect(entities[0].savedItem).toBeNull;
   });
 });

--- a/src/test/graphql/queries/pocketSave-item.integration.ts
+++ b/src/test/graphql/queries/pocketSave-item.integration.ts
@@ -29,7 +29,6 @@ describe('PocketSave.Item', () => {
                 }
                 ... on Item {
                   itemId
-                  givenUrl
                   __typename
                 }
               }
@@ -118,7 +117,6 @@ describe('PocketSave.Item', () => {
       });
     const expected = {
       itemId: '55',
-      givenUrl: 'https://www.youtube.com/watch?v=nsNMP6_Q0Js',
       __typename: 'Item',
     };
     expect(res.body.errors).toBeUndefined();

--- a/src/test/graphql/queries/savedItem.integration.ts
+++ b/src/test/graphql/queries/savedItem.integration.ts
@@ -137,7 +137,7 @@ describe('getSavedItemByItemId', () => {
     });
     expect(res.body.data?._entities[0].savedItemById).to.be.null;
   });
-  it('should resolve item url', async () => {
+  it('should resolve item ID', async () => {
     const variables = {
       userId: '1',
       itemId: '1',
@@ -153,7 +153,7 @@ describe('getSavedItemByItemId', () => {
               favoritedAt
               item {
                 ... on Item {
-                  givenUrl
+                  itemId
                 }
               }
             }
@@ -165,9 +165,7 @@ describe('getSavedItemByItemId', () => {
       query: GET_SAVED_ITEM_ITEM,
       variables,
     });
-    expect(res.body.data?._entities[0].savedItemById.item.givenUrl).to.equal(
-      'http://abc'
-    );
+    expect(res.body.data?._entities[0].savedItemById.item.itemId).to.equal('1');
   });
 
   it('should have _deletedAt field if item is deleted', async () => {

--- a/src/test/graphql/queries/savedItems.integration.ts
+++ b/src/test/graphql/queries/savedItems.integration.ts
@@ -40,7 +40,7 @@ describe('getSavedItems', () => {
                 url
                 item {
                   ... on Item {
-                    givenUrl
+                    itemId
                   }
                 }
               }
@@ -165,14 +165,14 @@ describe('getSavedItems', () => {
       'http://ijk'
     );
     expect(
-      res.body.data?._entities[0].savedItems.edges[0].node.item.givenUrl
-    ).to.equal('http://ijk');
+      res.body.data?._entities[0].savedItems.edges[0].node.item.itemId
+    ).to.equal('3');
     expect(res.body.data?._entities[0].savedItems.edges[1].node.url).to.equal(
       'http://def'
     );
     expect(
-      res.body.data?._entities[0].savedItems.edges[1].node.item.givenUrl
-    ).to.equal('http://def');
+      res.body.data?._entities[0].savedItems.edges[1].node.item.itemId
+    ).to.equal('2');
     expect(res.body.data?._entities[0].savedItems.pageInfo.hasNextPage).to.be
       .true;
     expect(res.body.data?._entities[0].savedItems.pageInfo.hasPreviousPage).to
@@ -195,8 +195,8 @@ describe('getSavedItems', () => {
       'http://abc'
     );
     expect(
-      res.body.data?._entities[0].savedItems.edges[0].node.item.givenUrl
-    ).to.equal('http://abc');
+      res.body.data?._entities[0].savedItems.edges[0].node.item.itemId
+    ).to.equal('1');
     expect(res.body.data?._entities[0].savedItems.pageInfo.hasNextPage).to.be
       .false;
     expect(res.body.data?._entities[0].savedItems.pageInfo.hasPreviousPage).to
@@ -248,8 +248,8 @@ describe('getSavedItems', () => {
     });
     expect(res.body.data?._entities[0].savedItems.edges.length).to.equal(1);
     expect(
-      res.body.data?._entities[0].savedItems.edges[0].node.item.givenUrl
-    ).to.equal('http://ijk');
+      res.body.data?._entities[0].savedItems.edges[0].node.item.itemId
+    ).to.equal('3');
     expect(res.body.data?._entities[0].savedItems.pageInfo.hasPreviousPage).to
       .be.false;
     expect(res.body.data?._entities[0].savedItems.pageInfo.hasNextPage).to.be
@@ -406,7 +406,7 @@ describe('getSavedItems', () => {
                   url
                   item {
                     ... on Item {
-                      givenUrl
+                      itemId
                     }
                   }
                 }
@@ -466,47 +466,47 @@ describe('getSavedItems', () => {
       {
         sortBy: 'CREATED_AT',
         sortOrder: 'DESC',
-        expectedUrls: ['http://ijk', 'http://def'],
+        expectedIds: ['3', '2'],
       },
       {
         sortBy: 'CREATED_AT',
         sortOrder: 'ASC',
-        expectedUrls: ['http://abc', 'http://def'],
+        expectedIds: ['1', '2'],
       },
       {
         sortBy: 'UPDATED_AT',
         sortOrder: 'DESC',
-        expectedUrls: ['http://def', 'http://abc'],
+        expectedIds: ['2', '1'],
       },
       {
         sortBy: 'UPDATED_AT',
         sortOrder: 'ASC',
-        expectedUrls: ['http://ijk', 'http://abc'],
+        expectedIds: ['3', '1'],
       },
       {
         sortBy: 'FAVORITED_AT',
         sortOrder: 'DESC',
-        expectedUrls: ['http://def', 'http://ijk'],
+        expectedIds: ['2', '3'],
       },
       {
         sortBy: 'FAVORITED_AT',
         // Note that this will put non-favorite items first (since they are set to time 0)
         sortOrder: 'ASC',
-        expectedUrls: ['http://abc', 'http://ijk'],
+        expectedIds: ['1', '3'],
       },
       {
         sortBy: 'ARCHIVED_AT',
         sortOrder: 'DESC',
-        expectedUrls: ['http://ijk', 'http://def'],
+        expectedIds: ['3', '2'],
       },
       {
         sortBy: 'ARCHIVED_AT',
         sortOrder: 'ASC',
-        expectedUrls: ['http://abc', 'http://def'],
+        expectedIds: ['1', '2'],
       },
     ])(
       ' by $sortBy, $sortOrder works',
-      async ({ sortBy, sortOrder, expectedUrls }) => {
+      async ({ sortBy, sortOrder, expectedIds }) => {
         const variables = {
           id: '1',
           pagination: { first: 2 },
@@ -517,10 +517,10 @@ describe('getSavedItems', () => {
           variables,
         });
         expect(res.body.errors).to.be.undefined;
-        const urls = res.body.data?._entities[0].savedItems.edges.map(
-          (edge) => edge.node.item.givenUrl
+        const ids = res.body.data?._entities[0].savedItems.edges.map(
+          (edge) => edge.node.item.itemId
         );
-        expect(expectedUrls).to.deep.equal(urls);
+        expect(expectedIds).to.deep.equal(ids);
       }
     );
   });

--- a/src/test/graphql/queries/tags.integration.ts
+++ b/src/test/graphql/queries/tags.integration.ts
@@ -292,7 +292,7 @@ describe('tags query tests - happy path', () => {
                       url
                       item {
                         ... on Item {
-                          givenUrl
+                          itemId
                         }
                       }
                     }
@@ -340,7 +340,7 @@ describe('tags query tests - happy path', () => {
                       url
                       item {
                         ... on Item {
-                          givenUrl
+                          itemId
                         }
                       }
                     }

--- a/src/test/integrations/eventBridge.integration.ts
+++ b/src/test/integrations/eventBridge.integration.ts
@@ -19,9 +19,6 @@ const testSavedItem: SavedItem = {
   isFavorite: true,
   isArchived: false,
   status: 'UNREAD',
-  item: {
-    givenUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-  },
   _createdAt: 1626389735,
 };
 

--- a/src/test/integrations/snowplowHandler.integration.ts
+++ b/src/test/integrations/snowplowHandler.integration.ts
@@ -88,9 +88,6 @@ const testSavedItem: SavedItem = {
   isFavorite: true,
   isArchived: false,
   status: 'UNREAD',
-  item: {
-    givenUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-  },
   _createdAt: 1626389735,
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,8 +58,8 @@ export type SavedItem = RemoteEntity & {
   favoritedAt?: number;
   isArchived: boolean;
   archivedAt?: number;
-  item: {
-    givenUrl: string;
+  item?: {
+    itemId: string;
   };
   tags?: Tag[];
 };


### PR DESCRIPTION
## Goal
Use item_id to federate Item instead of givenUrl. This is safer and more reliable due to the vagaries of URL encoding and whatnot...

See [slack](https://pocket.slack.com/archives/C03QVL4SU/p1684867901864509) for more context 