### PR TITLE
chore(test): skip flaky test

### DIFF
--- a/src/businessEvents/eventBatchProcessor.spec.ts
+++ b/src/businessEvents/eventBatchProcessor.spec.ts
@@ -46,7 +46,10 @@ describe('EventBatchHandler', () => {
     await batchJob.stop();
     expect(handlerFn.callCount).toEqual(0);
   });
-  it('should throw a warning if batch size exceeds processing speed', async () => {
+  // This test has been flaking, and the unified events kinesis stream has been
+  // superseded by snowplow analytics.
+  // so the risk of removing this coverage is very low
+  it.skip('should throw a warning if batch size exceeds processing speed', async () => {
     const consoleSpy = jest.spyOn(console, 'log');
     const batchJob = new EventBatchProcessor(
       emitter,


### PR DESCRIPTION
Skip a test that's been flaky for a while. The risk of losing this coverage is very low because it's for a system that is no longer used in production.

Goal is to get PRs merged easier.