### PR TITLE
feat(favorite/unfavorite): un/favorite by givenUrl

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -781,6 +781,16 @@ type Mutation {
   Unarchive a SavedItem (identified by URL)
   """
   savedItemUnArchive(givenUrl: Url!, timestamp: ISOString!): SavedItem
+
+  """
+  Favorite a SavedItem (identified by URL)
+  """
+  savedItemFavorite(givenUrl: Url!, timestamp: ISOString!): SavedItem
+
+  """
+  'Unfavorite' a 'favorite' SavedItem (identified by URL)
+  """
+  savedItemUnFavorite(givenUrl: Url!, timestamp: ISOString!): SavedItem
 }
 
 # """

--- a/src/dataService/savedItemsService.ts
+++ b/src/dataService/savedItemsService.ts
@@ -177,13 +177,16 @@ export class SavedItemDataService {
    * in the table ('time_updated', etc.)
    * @param itemId the item ID to update
    * @param favorite whether the item is a favorite or not
+   * @param updatedAt optional timestamp for when the mutation occured
+   * (defaults to current server time)
    * @returns savedItem savedItem that got updated
    */
   public async updateSavedItemFavoriteProperty(
     itemId: string,
-    favorite: boolean
-  ): Promise<SavedItem> {
-    const timestamp = SavedItemDataService.formatDate(new Date());
+    favorite: boolean,
+    updatedAt?: Date
+  ): Promise<SavedItem | null> {
+    const timestamp = updatedAt ?? SavedItemDataService.formatDate(new Date());
     const timeFavorited = favorite ? timestamp : '0000-00-00 00:00:00';
     await this.db('list')
       .update({

--- a/src/models/SavedItem.ts
+++ b/src/models/SavedItem.ts
@@ -61,6 +61,54 @@ export class SavedItemModel {
   }
 
   /**
+   * 'Favorite' a Save in a Pocket User's list
+   * @param id the ID of the SavedItem to favorite
+   * @param timestamp timestamp for when the mutation occurred. Optional
+   * to support old id-keyed mutations that didn't require timetsamp.
+   * If not provided, defaults to current server time.
+   * @returns The updated SavedItem if it exists, or null if it doesn't
+   * @throws NotFound if the SavedItem doesn't exist
+   */
+  public async favoriteById(
+    id: string,
+    timestamp?: Date
+  ): Promise<SavedItem | null> {
+    const savedItem = await this.saveService.updateSavedItemFavoriteProperty(
+      id,
+      true,
+      timestamp
+    );
+    if (savedItem == null) {
+      throw new NotFoundError(this.defaultNotFoundMessage);
+    } else {
+      this.context.emitItemEvent(EventType.FAVORITE_ITEM, savedItem);
+    }
+    return savedItem;
+  }
+  /**
+   * 'Unfavorite' a Save in a Pocket User's list
+   * @param id the ID of the SavedItem to unfavorite (move to 'saves')
+   * @param timestamp timestamp for when the mutation occurred. Optional
+   * to support old id-keyed mutations that didn't require timetsamp.
+   * If not provided, defaults to current server time.
+   * @returns The updated SavedItem if it exists, or null if it doesn't
+   * @throws NotFound if the SavedItem doesn't exist
+   */
+  public async unfavoriteById(id: string, timestamp?: Date) {
+    const savedItem = await this.saveService.updateSavedItemFavoriteProperty(
+      id,
+      false,
+      timestamp
+    );
+    if (savedItem == null) {
+      throw new NotFoundError(this.defaultNotFoundMessage);
+    } else {
+      this.context.emitItemEvent(EventType.UNFAVORITE_ITEM, savedItem);
+    }
+    return savedItem;
+  }
+
+  /**
    * 'Archive' a Save in a Pocket User's list
    * @param url the given url of the SavedItem to archive
    * @param timestamp timestamp for when the mutation occurred
@@ -87,6 +135,35 @@ export class SavedItemModel {
   ): Promise<SavedItem | null> {
     const id = await this.fetchIdFromUrl(url);
     return this.unarchiveById(id, timestamp);
+  }
+
+  /**
+   * 'Favorite' a Save in a Pocket User's list
+   * @param url the given url of the SavedItem to favorite
+   * @param timestamp timestamp for when the mutation occurred
+   * @returns The updated SavedItem if it exists, or null if it doesn't
+   * @throws NotFound if the SavedItem doesn't exist
+   */
+  public async favoriteByUrl(
+    url: string,
+    timestamp: Date
+  ): Promise<SavedItem | null> {
+    const id = await this.fetchIdFromUrl(url);
+    return this.favoriteById(id, timestamp);
+  }
+  /**
+   * 'Unfavorite' a Save in a Pocket User's list
+   * @param url the given url of the SavedItem to unfavorite
+   * @param timestamp timestamp for when the mutation occurred
+   * @returns The updated SavedItem if it exists, or null if it doesn't
+   * @throws NotFound if the SavedItem doesn't exist
+   */
+  public async unfavoriteByUrl(
+    url: string,
+    timestamp: Date
+  ): Promise<SavedItem | null> {
+    const id = await this.fetchIdFromUrl(url);
+    return this.unfavoriteById(id, timestamp);
   }
 
   /**

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -231,6 +231,26 @@ const resolvers = {
         args.timestamp
       );
     },
+    savedItemFavorite: async (
+      _,
+      args: { givenUrl: string; timestamp: Date },
+      context: IContext
+    ): Promise<SavedItem | null> => {
+      return await context.models.savedItem.favoriteByUrl(
+        args.givenUrl,
+        args.timestamp
+      );
+    },
+    savedItemUnFavorite: async (
+      _,
+      args: { givenUrl: string; timestamp: Date },
+      context: IContext
+    ): Promise<SavedItem | null> => {
+      return await context.models.savedItem.unfavoriteByUrl(
+        args.givenUrl,
+        args.timestamp
+      );
+    },
   },
 };
 

--- a/src/resolvers/mutation.ts
+++ b/src/resolvers/mutation.ts
@@ -94,13 +94,7 @@ export async function updateSavedItemFavorite(
   args: { id: string },
   context: IContext
 ): Promise<SavedItem> {
-  const savedItemService = new SavedItemDataService(context);
-  const savedItem = await savedItemService.updateSavedItemFavoriteProperty(
-    args.id,
-    true
-  );
-  context.emitItemEvent(EventType.FAVORITE_ITEM, savedItem);
-  return savedItem;
+  return context.models.savedItem.favoriteById(args.id);
 }
 
 /**
@@ -114,13 +108,7 @@ export async function updateSavedItemUnFavorite(
   args: { id: string },
   context: IContext
 ): Promise<SavedItem> {
-  const savedItemService = new SavedItemDataService(context);
-  const savedItem = await savedItemService.updateSavedItemFavoriteProperty(
-    args.id,
-    false
-  );
-  context.emitItemEvent(EventType.UNFAVORITE_ITEM, savedItem);
-  return savedItem;
+  return context.models.savedItem.unfavoriteById(args.id);
 }
 
 /**

--- a/src/test/graphql/mutations/savedItem/savedItemFavorite.integration.ts
+++ b/src/test/graphql/mutations/savedItem/savedItemFavorite.integration.ts
@@ -1,0 +1,203 @@
+import { writeClient } from '../../../../database/client';
+import sinon from 'sinon';
+import { ContextManager } from '../../../../server/context';
+import { startServer } from '../../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+import { mockParserGetItemIdRequest } from '../../../utils/parserMocks';
+
+describe('savedItemFavorite mutation', function () {
+  const db = writeClient();
+  const eventSpy = sinon.spy(ContextManager.prototype, 'emitItemEvent');
+  const headers = { userid: '1' };
+  const date = new Date('2020-10-03T10:20:30.000Z'); // Consistent date for seeding
+  const date1 = new Date('2020-10-03T10:30:30.000Z'); // Consistent date for seeding
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const FAVORITE_MUTATION = gql`
+    mutation savedItemFavorite($givenUrl: Url!, $timestamp: ISOString!) {
+      savedItemFavorite(givenUrl: $givenUrl, timestamp: $timestamp) {
+        id
+        url
+        isFavorite
+        favoritedAt
+        _updatedAt
+      }
+    }
+  `;
+
+  beforeEach(async () => {
+    await db('list').truncate();
+    const inputData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 0, favorite: 0 },
+      // One that's already favorite
+      { item_id: 2, status: 1, favorite: 1 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date1,
+        time_read: row.status === 1 ? date : '0000-00-00 00:00:00',
+        time_favorited: row.favorite === 1 ? date : '0000-00-00 00:00:00',
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await db('list').insert(inputData);
+  });
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+    sinon.restore();
+    await server.stop();
+  });
+
+  afterEach(() => sinon.resetHistory());
+
+  it('should favorite a non-favorite savedItem', async () => {
+    const givenUrl = 'http://1';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(FAVORITE_MUTATION), variables });
+
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data.savedItemFavorite).toStrictEqual({
+      id: '1',
+      url: givenUrl,
+      isFavorite: true,
+      favoritedAt: testEpoch,
+      _updatedAt: testEpoch,
+    });
+  });
+  it('throws NotFound error if the savedItem does not have an itemId', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(FAVORITE_MUTATION), variables });
+    expect(res.body.errors).toContainEqual(
+      expect.objectContaining({
+        extensions: { code: 'NOT_FOUND' },
+        message: expect.stringContaining('SavedItem does not exist'),
+      })
+    );
+  });
+  it('should not emit an favorite event if the savedItem did not have an itemId', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(FAVORITE_MUTATION), variables });
+    expect(eventSpy.callCount).toEqual(0);
+  });
+  it('throws NotFound error and does not emit event if the savedItem does not exist in the pocket user saves', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, '999');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(FAVORITE_MUTATION), variables });
+    expect(res.body.errors).toContainEqual(
+      expect.objectContaining({
+        extensions: { code: 'NOT_FOUND' },
+        message: expect.stringContaining('SavedItem does not exist'),
+      })
+    );
+    expect(eventSpy.callCount).toEqual(0);
+  });
+  it('should emit an favorite event when a savedItem is favorited', async () => {
+    const givenUrl = 'http://1';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(FAVORITE_MUTATION), variables });
+    expect(eventSpy.callCount).toEqual(1);
+    expect(eventSpy.firstCall.args).toStrictEqual([
+      'FAVORITE_ITEM',
+      expect.objectContaining({
+        url: givenUrl,
+        time_updated: new Date(testTimestamp),
+      }),
+    ]);
+  });
+  // This might change to a no-op later, but let's stick with current behavior of
+  // updatesavedItemFavorite and have it documented in tests
+  it('works even if the savedItem is already favorited, updating timestamps and emitting event', async () => {
+    const givenUrl = 'http://2';
+    mockParserGetItemIdRequest(givenUrl, '2');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(FAVORITE_MUTATION), variables });
+
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data.savedItemFavorite).toStrictEqual({
+      id: '2',
+      url: givenUrl,
+      isFavorite: true,
+      favoritedAt: testEpoch,
+      _updatedAt: testEpoch,
+    });
+    expect(eventSpy.callCount).toEqual(1);
+    expect(eventSpy.firstCall.args).toStrictEqual([
+      'FAVORITE_ITEM',
+      expect.objectContaining({
+        url: givenUrl,
+        time_updated: new Date(testTimestamp),
+      }),
+    ]);
+  });
+});

--- a/src/test/graphql/mutations/savedItem/savedItemUnFavorite.integration.ts
+++ b/src/test/graphql/mutations/savedItem/savedItemUnFavorite.integration.ts
@@ -1,0 +1,203 @@
+import { writeClient } from '../../../../database/client';
+import sinon from 'sinon';
+import { ContextManager } from '../../../../server/context';
+import { startServer } from '../../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+import { mockParserGetItemIdRequest } from '../../../utils/parserMocks';
+
+describe('savedItemUnFavorite mutation', function () {
+  const db = writeClient();
+  const eventSpy = sinon.spy(ContextManager.prototype, 'emitItemEvent');
+  const headers = { userid: '1' };
+  const date = new Date('2020-10-03T10:20:30.000Z'); // Consistent date for seeding
+  const date1 = new Date('2020-10-03T10:30:30.000Z'); // Consistent date for seeding
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const UNFAVORITE_MUTATION = gql`
+    mutation savedItemUnFavorite($givenUrl: Url!, $timestamp: ISOString!) {
+      savedItemUnFavorite(givenUrl: $givenUrl, timestamp: $timestamp) {
+        id
+        url
+        isFavorite
+        favoritedAt
+        _updatedAt
+      }
+    }
+  `;
+
+  beforeEach(async () => {
+    await db('list').truncate();
+    const inputData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 0, favorite: 0 },
+      // One that's already favorite
+      { item_id: 2, status: 1, favorite: 1 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date1,
+        time_read: row.status === 1 ? date : '0000-00-00 00:00:00',
+        time_favorited: row.favorite === 1 ? date : '0000-00-00 00:00:00',
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await db('list').insert(inputData);
+  });
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+    sinon.restore();
+    await server.stop();
+  });
+
+  afterEach(() => sinon.resetHistory());
+
+  it('should unfavorite a favorited savedItem', async () => {
+    const givenUrl = 'http://2';
+    mockParserGetItemIdRequest(givenUrl, '2');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNFAVORITE_MUTATION), variables });
+
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data.savedItemUnFavorite).toStrictEqual({
+      id: '2',
+      url: givenUrl,
+      isFavorite: false,
+      favoritedAt: null,
+      _updatedAt: testEpoch,
+    });
+  });
+  it('throws NotFound error if the savedItem does not have an itemId', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNFAVORITE_MUTATION), variables });
+    expect(res.body.errors).toContainEqual(
+      expect.objectContaining({
+        extensions: { code: 'NOT_FOUND' },
+        message: expect.stringContaining('SavedItem does not exist'),
+      })
+    );
+  });
+  it('should not emit an unfavorite event if the savedItem did not have an itemId', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNFAVORITE_MUTATION), variables });
+    expect(eventSpy.callCount).toEqual(0);
+  });
+  it('throws NotFound error and does not emit event if the savedItem does not exist in the pocket user saves', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, '999');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNFAVORITE_MUTATION), variables });
+    expect(res.body.errors).toContainEqual(
+      expect.objectContaining({
+        extensions: { code: 'NOT_FOUND' },
+        message: expect.stringContaining('SavedItem does not exist'),
+      })
+    );
+    expect(eventSpy.callCount).toEqual(0);
+  });
+  it('should emit an unfavorite event when a savedItem is unfavorited', async () => {
+    const givenUrl = 'http://2';
+    mockParserGetItemIdRequest(givenUrl, '2');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNFAVORITE_MUTATION), variables });
+    expect(eventSpy.callCount).toEqual(1);
+    expect(eventSpy.firstCall.args).toStrictEqual([
+      'UNFAVORITE_ITEM',
+      expect.objectContaining({
+        url: givenUrl,
+        time_updated: new Date(testTimestamp),
+      }),
+    ]);
+  });
+  // This might change to a no-op later, but let's stick with current behavior of
+  // updatesavedItemUnFavorite and have it documented in tests
+  it('works even if the savedItem is not favorited, updating timestamps and emitting event', async () => {
+    const givenUrl = 'http://1';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UNFAVORITE_MUTATION), variables });
+
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data.savedItemUnFavorite).toStrictEqual({
+      id: '1',
+      url: givenUrl,
+      isFavorite: false,
+      favoritedAt: null,
+      _updatedAt: testEpoch,
+    });
+    expect(eventSpy.callCount).toEqual(1);
+    expect(eventSpy.firstCall.args).toStrictEqual([
+      'UNFAVORITE_ITEM',
+      expect.objectContaining({
+        url: givenUrl,
+        time_updated: new Date(testTimestamp),
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Goal
Add mutation to favorite/unfavorite by url identifier, to support offline mobile clients.
Extends the same pattern as #801

## Implementation Decisions
- Continuing the same pattern as archive/unarchive in #801 


## References

Jira ticket:
* [IN-1473]
* [IN-1471]


[IN-1473]: https://getpocket.atlassian.net/browse/IN-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IN-1471]: https://getpocket.atlassian.net/browse/IN-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ