### PR TITLE
feat(delete): delete a SavedItem by url

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -647,10 +647,6 @@ type Mutation {
   """
   updateSavedItemUnArchive(id: ID!): SavedItem!
 
-  """
-  Undo the delete operation for a SavedItem
-  """
-  updateSavedItemUnDelete(id: ID!): SavedItem!
 
   """
   Favorites a SavedItem
@@ -791,6 +787,16 @@ type Mutation {
   'Unfavorite' a 'favorite' SavedItem (identified by URL)
   """
   savedItemUnFavorite(givenUrl: Url!, timestamp: ISOString!): SavedItem
+
+  """
+  'Soft-delete' a SavedItem (identified by URL)
+  """
+  savedItemDelete(givenUrl: Url!, timestamp: ISOString!): Url
+
+  """
+  Undo the 'soft-delete' operation on a SavedItem (identified by URL)
+  """
+  savedItemUnDelete(givenUrl: Url!, timestamp: ISOString!): SavedItem
 }
 
 # """

--- a/schema.graphql
+++ b/schema.graphql
@@ -647,6 +647,10 @@ type Mutation {
   """
   updateSavedItemUnArchive(id: ID!): SavedItem!
 
+  """
+  Undo the delete operation for a SavedItem
+  """
+  updateSavedItemUnDelete(id: ID!): SavedItem!
 
   """
   Favorites a SavedItem
@@ -793,10 +797,6 @@ type Mutation {
   """
   savedItemDelete(givenUrl: Url!, timestamp: ISOString!): Url
 
-  """
-  Undo the 'soft-delete' operation on a SavedItem (identified by URL)
-  """
-  savedItemUnDelete(givenUrl: Url!, timestamp: ISOString!): SavedItem
 }
 
 # """

--- a/src/dataService/savedItemsService.ts
+++ b/src/dataService/savedItemsService.ts
@@ -238,8 +238,11 @@ export class SavedItemDataService {
    * to allow us to fully rollback should any on of the
    * database statements fail.
    * @param itemId the itemId to delete
+   * @param deletedAt optional timestamp for when the mutation was completed;
+   * defaults to current server time
    */
-  public async deleteSavedItem(itemId) {
+  public async deleteSavedItem(itemId, deletedAt?: Date) {
+    const timestamp = deletedAt ?? SavedItemDataService.formatDate(new Date());
     const transaction = await this.db.transaction();
     try {
       // remove tags for saved item
@@ -264,7 +267,7 @@ export class SavedItemDataService {
       await transaction('list')
         .update({
           status: SavedItemStatus.DELETED,
-          time_updated: SavedItemDataService.formatDate(new Date()),
+          time_updated: timestamp,
           api_id_updated: this.apiId,
         })
         .where({ item_id: itemId, user_id: this.userId });

--- a/src/models/SavedItem.ts
+++ b/src/models/SavedItem.ts
@@ -109,6 +109,29 @@ export class SavedItemModel {
   }
 
   /**
+   * 'Soft-delete' a Save in a Pocket User's list. Removes tags, scroll
+   * sync position, and attributions associated with the SavedItem, then
+   * sets the status to 'deleted'.
+   * @param id the ID of the SavedItem to delete
+   * @param timestamp timestamp for when the mutation occurred. Optional
+   * to support old id-keyed mutations that didn't require timetsamp.
+   * If not provided, defaults to current server time.
+   * @returns The ID of the deleted SavedItem, or null if it does not exist
+   * @throws NotFound if the SavedItem doesn't exist
+   */
+  public async deleteById(id: string, timestamp?: Date) {
+    // TODO: setup a process to delete saved items X number of days after deleted
+    await this.saveService.deleteSavedItem(id, timestamp);
+    const savedItem = await this.saveService.getSavedItemById(id);
+    if (savedItem == null) {
+      throw new NotFoundError(this.defaultNotFoundMessage);
+    } else {
+      this.context.emitItemEvent(EventType.DELETE_ITEM, savedItem);
+    }
+    return id;
+  }
+
+  /**
    * 'Archive' a Save in a Pocket User's list
    * @param url the given url of the SavedItem to archive
    * @param timestamp timestamp for when the mutation occurred
@@ -164,6 +187,22 @@ export class SavedItemModel {
   ): Promise<SavedItem | null> {
     const id = await this.fetchIdFromUrl(url);
     return this.unfavoriteById(id, timestamp);
+  }
+
+  /**
+   * 'Soft-delete' a Save in a Pocket User's list. Removes tags, scroll
+   * sync position, and attributions associated with the SavedItem, then
+   * sets the status to 'deleted'.
+   * @param id the ID of the SavedItem to delete
+   * @param timestamp timestamp for when the mutation occurred
+   * @returns The ID of the deleted SavedItem, or null if it does not exist
+   * @throws NotFound if the SavedItem doesn't exist
+   */
+  public async deleteByUrl(url: string, timestamp?: Date) {
+    const id = await this.fetchIdFromUrl(url);
+    // Will throw if fails or returns null
+    await this.deleteById(id, timestamp);
+    return url;
   }
 
   /**

--- a/src/models/SavedItem.ts
+++ b/src/models/SavedItem.ts
@@ -198,7 +198,7 @@ export class SavedItemModel {
    * sets the status to 'deleted'.
    * @param id the ID of the SavedItem to delete
    * @param timestamp timestamp for when the mutation occurred
-   * @returns The ID of the deleted SavedItem, or null if it does not exist
+   * @returns The url of the deleted SavedItem, or null if it does not exist
    * @throws NotFound if the SavedItem doesn't exist
    */
   public async deleteByUrl(

--- a/src/models/SavedItem.ts
+++ b/src/models/SavedItem.ts
@@ -119,7 +119,10 @@ export class SavedItemModel {
    * @returns The ID of the deleted SavedItem, or null if it does not exist
    * @throws NotFound if the SavedItem doesn't exist
    */
-  public async deleteById(id: string, timestamp?: Date) {
+  public async deleteById(
+    id: string,
+    timestamp?: Date
+  ): Promise<string | null> {
     // TODO: setup a process to delete saved items X number of days after deleted
     await this.saveService.deleteSavedItem(id, timestamp);
     const savedItem = await this.saveService.getSavedItemById(id);
@@ -198,7 +201,10 @@ export class SavedItemModel {
    * @returns The ID of the deleted SavedItem, or null if it does not exist
    * @throws NotFound if the SavedItem doesn't exist
    */
-  public async deleteByUrl(url: string, timestamp?: Date) {
+  public async deleteByUrl(
+    url: string,
+    timestamp: Date
+  ): Promise<string | null> {
     const id = await this.fetchIdFromUrl(url);
     // Will throw if fails or returns null
     await this.deleteById(id, timestamp);

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -251,6 +251,16 @@ const resolvers = {
         args.timestamp
       );
     },
+    savedItemDelete: async (
+      _,
+      args: { givenUrl: string; timestamp: Date },
+      context: IContext
+    ): Promise<string | null> => {
+      return await context.models.savedItem.deleteByUrl(
+        args.givenUrl,
+        args.timestamp
+      );
+    },
   },
 };
 

--- a/src/resolvers/mutation.ts
+++ b/src/resolvers/mutation.ts
@@ -150,12 +150,7 @@ export async function deleteSavedItem(
   args: { id: string },
   context: IContext
 ): Promise<string> {
-  // TODO: setup a process to delete saved items X number of days after deleted
-  const savedItemService = new SavedItemDataService(context);
-  await savedItemService.deleteSavedItem(args.id);
-  const savedItem = await savedItemService.getSavedItemById(args.id);
-  context.emitItemEvent(EventType.DELETE_ITEM, savedItem);
-  return args.id;
+  return context.models.savedItem.deleteById(args.id);
 }
 
 /**

--- a/src/test/graphql/mutations/savedItem/savedItemDelete.integration.ts
+++ b/src/test/graphql/mutations/savedItem/savedItemDelete.integration.ts
@@ -1,0 +1,282 @@
+import { writeClient } from '../../../../database/client';
+import sinon from 'sinon';
+import { ContextManager } from '../../../../server/context';
+import { startServer } from '../../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+import { mockParserGetItemIdRequest } from '../../../utils/parserMocks';
+
+describe('savedItemDelete mutation', function () {
+  const db = writeClient();
+  const eventSpy = sinon.spy(ContextManager.prototype, 'emitItemEvent');
+  const headers = { userid: '1' };
+  const date = new Date('2020-10-03T10:20:30.000Z'); // Consistent date for seeding
+  const date1 = new Date('2020-10-03T10:30:30.000Z'); // Consistent date for seeding
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const GET_SAVE_QUERY = gql`
+    query getSavedItem($itemId: ID!) {
+      _entities(representations: { id: "1", __typename: "User" }) {
+        ... on User {
+          savedItemById(id: $itemId) {
+            url
+            status
+            _updatedAt
+            _deletedAt
+            tags {
+              name
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const DELETE_MUTATION = gql`
+    mutation savedItemDelete($givenUrl: Url!, $timestamp: ISOString!) {
+      savedItemDelete(givenUrl: $givenUrl, timestamp: $timestamp)
+    }
+  `;
+
+  beforeEach(async () => {
+    await db('list').truncate();
+    await db('item_tags').truncate();
+    const inputData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 1, favorite: 0 },
+      // One that's already deleted
+      { item_id: 2, status: 2, favorite: 0 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date1,
+        time_read: row.status === 1 ? date : '0000-00-00 00:00:00',
+        time_favorited: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await db('list').insert(inputData);
+    // Add some tags which can be deleted
+    const tagData = ['0', '1', '2'].flatMap((id) => {
+      const tagBase = {
+        user_id: 1,
+        status: 1,
+        time_added: date,
+        time_updated: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+      return [
+        {
+          ...tagBase,
+          tag: 'odd',
+          item_id: id,
+        },
+        {
+          ...tagBase,
+          tag: 'taxi',
+          item_id: id,
+        },
+      ];
+    });
+    await db('item_tags').insert(tagData);
+  });
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+    sinon.restore();
+    await server.stop();
+  });
+
+  afterEach(() => sinon.resetHistory());
+
+  it('should "soft-delete" an "unread" savedItem', async () => {
+    const givenUrl = 'http://0';
+    mockParserGetItemIdRequest(givenUrl, '0');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+
+    const deleteRes = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(DELETE_MUTATION), variables });
+
+    const roundTripRes = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(GET_SAVE_QUERY), variables: { itemId: '0' } });
+
+    expect(deleteRes.body.errors).toBeUndefined();
+    expect(deleteRes.body.data.savedItemDelete).toStrictEqual('http://0');
+    expect(roundTripRes.body.data._entities[0].savedItemById).toStrictEqual({
+      url: givenUrl,
+      status: 'DELETED',
+      _updatedAt: testEpoch,
+      _deletedAt: testEpoch,
+      tags: [],
+    });
+  });
+  it('should "soft-delete" an "archived" savedItem', async () => {
+    const givenUrl = 'http://1';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+
+    const deleteRes = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(DELETE_MUTATION), variables });
+
+    const roundTripRes = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(GET_SAVE_QUERY), variables: { itemId: '1' } });
+
+    expect(deleteRes.body.errors).toBeUndefined();
+    expect(deleteRes.body.data.savedItemDelete).toStrictEqual('http://1');
+    expect(roundTripRes.body.data._entities[0].savedItemById).toStrictEqual({
+      url: givenUrl,
+      status: 'DELETED',
+      _updatedAt: testEpoch,
+      _deletedAt: testEpoch,
+      tags: [],
+    });
+  });
+  it('throws NotFound error if the savedItem does not have an itemId', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(DELETE_MUTATION), variables });
+    expect(res.body.errors).toContainEqual(
+      expect.objectContaining({
+        extensions: { code: 'NOT_FOUND' },
+        message: expect.stringContaining('SavedItem does not exist'),
+      })
+    );
+  });
+  it('should not emit a delete event if the savedItem did not have an itemId', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(DELETE_MUTATION), variables });
+    expect(eventSpy.callCount).toEqual(0);
+  });
+  it('throws NotFound error and does not emit event if the savedItem is not in the user saves', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, '999');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(DELETE_MUTATION), variables });
+    expect(res.body.errors).toContainEqual(
+      expect.objectContaining({
+        extensions: { code: 'NOT_FOUND' },
+        message: expect.stringContaining('SavedItem does not exist'),
+      })
+    );
+    expect(eventSpy.callCount).toEqual(0);
+  });
+  it('should emit a delete event when a savedItem is deleted', async () => {
+    const givenUrl = 'http://1';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+    await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(DELETE_MUTATION), variables });
+    expect(eventSpy.callCount).toEqual(1);
+    expect(eventSpy.firstCall.args).toStrictEqual([
+      'DELETE_ITEM',
+      expect.objectContaining({
+        url: givenUrl,
+        time_updated: new Date(testTimestamp),
+      }),
+    ]);
+  });
+  // This might change to a no-op later, but let's stick with current behavior of
+  // updatesavedItemDelete and have it documented in tests
+  it('works even if the savedItem is already "soft-deleted", updating timestamps and emitting event', async () => {
+    const givenUrl = 'http://2';
+    mockParserGetItemIdRequest(givenUrl, '2');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(DELETE_MUTATION), variables });
+
+    const roundTripRes = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(GET_SAVE_QUERY), variables: { itemId: '2' } });
+
+    expect(roundTripRes.body.data._entities[0].savedItemById).toStrictEqual({
+      url: givenUrl,
+      status: 'DELETED',
+      _updatedAt: testEpoch,
+      _deletedAt: testEpoch,
+      tags: [],
+    });
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data.savedItemDelete).toStrictEqual(givenUrl);
+    expect(eventSpy.callCount).toEqual(1);
+    expect(eventSpy.firstCall.args).toStrictEqual([
+      'DELETE_ITEM',
+      expect.objectContaining({
+        url: givenUrl,
+        time_updated: new Date(testTimestamp),
+      }),
+    ]);
+  });
+});

--- a/src/test/graphql/mutations/savedItem/savedItemDelete.integration.ts
+++ b/src/test/graphql/mutations/savedItem/savedItemDelete.integration.ts
@@ -126,7 +126,7 @@ describe('savedItemDelete mutation', function () {
       .send({ query: print(GET_SAVE_QUERY), variables: { itemId: '0' } });
 
     expect(deleteRes.body.errors).toBeUndefined();
-    expect(deleteRes.body.data.savedItemDelete).toStrictEqual('http://0');
+    expect(deleteRes.body.data.savedItemDelete).toStrictEqual(givenUrl);
     expect(roundTripRes.body.data._entities[0].savedItemById).toStrictEqual({
       url: givenUrl,
       status: 'DELETED',
@@ -156,7 +156,7 @@ describe('savedItemDelete mutation', function () {
       .send({ query: print(GET_SAVE_QUERY), variables: { itemId: '1' } });
 
     expect(deleteRes.body.errors).toBeUndefined();
-    expect(deleteRes.body.data.savedItemDelete).toStrictEqual('http://1');
+    expect(deleteRes.body.data.savedItemDelete).toStrictEqual(givenUrl);
     expect(roundTripRes.body.data._entities[0].savedItemById).toStrictEqual({
       url: givenUrl,
       status: 'DELETED',

--- a/src/test/integrations/savedItemsService.integration.ts
+++ b/src/test/integrations/savedItemsService.integration.ts
@@ -1,16 +1,12 @@
-import chai, { expect } from 'chai';
 import { readClient, writeClient } from '../../database/client';
 import { SavedItemDataService } from '../../dataService';
 import { ContextManager } from '../../server/context';
-import deepEqualInAnyOrder from 'deep-equal-in-any-order';
-
-chai.use(deepEqualInAnyOrder);
 
 describe('SavedItemsService', () => {
-  beforeAll(async () => {
-    const db = writeClient();
-    const date = new Date('2020-10-03 10:20:30');
+  const db = writeClient();
+  const date = new Date('2020-10-03 10:20:30');
 
+  beforeAll(async () => {
     await db('list').truncate();
     await db('list').insert([
       {
@@ -59,8 +55,8 @@ describe('SavedItemsService', () => {
       context
     ).batchGetSavedItemsByGivenUrls(['https://abc', 'https://def']);
 
-    expect(savedItems[0].url).to.equal('https://abc');
-    expect(savedItems[1].url).to.equal('https://def');
+    expect(savedItems[0].url).toStrictEqual('https://abc');
+    expect(savedItems[1].url).toStrictEqual('https://def');
   });
 
   it('fetches saved items for multiple ids for the same user', async () => {
@@ -76,8 +72,8 @@ describe('SavedItemsService', () => {
       context
     ).batchGetSavedItemsByGivenIds(['1', '2']);
 
-    expect(savedItems[0].url).to.equal('https://abc');
-    expect(savedItems[1].url).to.equal('https://def');
+    expect(savedItems[0].url).toStrictEqual('https://abc');
+    expect(savedItems[1].url).toStrictEqual('https://def');
   });
 
   it('fetches saved item IDs up to a given limit', async () => {
@@ -93,7 +89,7 @@ describe('SavedItemsService', () => {
       context
     ).getSavedItemIds(0, 1);
 
-    expect(savedItemIds[0]).to.equal(1);
+    expect(savedItemIds[0]).toStrictEqual(1);
   });
 
   it('fetches saved item IDs up to a given limit starting from a given offset', async () => {
@@ -109,7 +105,7 @@ describe('SavedItemsService', () => {
       context
     ).getSavedItemIds(1, 1);
 
-    expect(savedItemIds[0]).to.equal(2);
+    expect(savedItemIds[0]).toStrictEqual(2);
   });
 
   it('returns an empty list if the offset is past the end of the list', async () => {
@@ -125,6 +121,49 @@ describe('SavedItemsService', () => {
       context
     ).getSavedItemIds(4, 1);
 
-    expect(savedItemIds.length).to.equal(0);
+    expect(savedItemIds.length).toStrictEqual(0);
+  });
+  describe('.deleteSavedItem', () => {
+    const itemId = 1;
+    const query = async (tableName: string) =>
+      await db(tableName)
+        .select()
+        .where({ user_id: 1, item_id: itemId })
+        .first();
+    beforeAll(async () => {
+      await db('item_attribution').truncate();
+      await db('items_scroll').truncate();
+      await db('item_attribution').insert([
+        {
+          user_id: 1,
+          item_id: itemId,
+          attribution_type_id: 101,
+        },
+      ]);
+      await db('items_scroll').insert({
+        user_id: 1,
+        item_id: itemId,
+        view: 1,
+        section: 0,
+        page: 1,
+        node_index: 10,
+        scroll_percent: 10,
+        time_updated: date,
+        updated_at: date,
+      });
+    });
+    it('deletes from non-client-facing tables', async () => {
+      const context = new ContextManager({
+        request: {
+          headers: { userid: '1', apiid: '0' },
+        },
+        dbClient: writeClient(),
+        eventEmitter: null,
+      });
+      await new SavedItemDataService(context).deleteSavedItem(itemId);
+      // Adding coverage for data not made available through the API
+      expect(await query('item_attribution')).toBeUndefined();
+      expect(await query('items_scroll')).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Goal
Add mutation to delete a SavedItem by url. Continuing on the theme from #801 and #802

## I'd love feedback/perspectives on:
- any

## Implementation Decisions
- putting non-user-facing delete tests on the data service integration test vs. bundling with the graphql e2e tests

## References

Jira ticket:
* [IN-1475]


[IN-1475]: https://getpocket.atlassian.net/browse/IN-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ