### PR TITLE
fix(event bus): send to shared event bus (instead of default)

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -44,7 +44,7 @@ export const config = {
     sqsPermLibItemMainQueueName: `PermLib-${environment}-ItemMain`,
     unifiedEventStreamName: 'unified_event',
     databaseTz: 'US/Central',
-    eventBusName: `default`,
+    eventBusName: `PocketEventBridge-${environment}-Shared-Event-Bus`,
   },
   lambda: {
     snsTopicName: {


### PR DESCRIPTION
## Goal

send events to the shared event bus. [successfully pushed to dev](https://app.circleci.com/pipelines/github/Pocket/list-api/5598/workflows/bc883721-876c-4aba-9c23-2f69a8c10705).

anything else we need to check here?

## References

Jira ticket:
* https://getpocket.atlassian.net/browse/OSL-549