### PR TITLE
chore(savedItem.title): deprecate savedItem.title in schema docs

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -149,9 +149,10 @@ type SavedItem implements RemoteEntity @key(fields: "id") @key(fields: "url") {
   """
   url: String!
   """
-  The title for user saved item. Set by the user and if not, set by the parser
+  The title for user saved item. Set by the user and if not, set by the parser.
+  Supported for third party clients use-case
   """
-  title: String
+  title: String @deprecated(reason: "internal clients must use item.title") @tag(name: "alpha")
   """
   Helper property to indicate if the SavedItem is favorited
   """

--- a/schema.graphql
+++ b/schema.graphql
@@ -150,7 +150,7 @@ type SavedItem implements RemoteEntity @key(fields: "id") @key(fields: "url") {
   url: String!
   """
   The title for user saved item. Set by the user and if not, set by the parser.
-  Supported for third party clients use-case
+  For third party clients use-case only.
   """
   title: String @deprecated(reason: "internal clients must use item.title") @tag(name: "alpha")
   """


### PR DESCRIPTION
## goal

- mark `savedItem.title` as alpha as its not resolved yet
- mark them as deprecated as we will use it only for third party clients API (v3 proxy work). internal clients are expected to use `item.title`