### PR TITLE
INFRA-1324: remove itemId from extended Item type

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,12 +1,14 @@
 extend schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
-        import: ["@key", "@composeDirective", "@tag", "@shareable"])
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.3"
+    import: ["@key", "@composeDirective", "@tag", "@shareable"]
+  )
   # The link directive is required to federate @constraint
   # It doesn't actually have to be a real spec, but it would be good
   # to write one and replace this.
   @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@constraint"])
-  @composeDirective(name:"@constraint")
+  @composeDirective(name: "@constraint")
 
 """
 ISOString scalar - all datetimes fields are Typescript Date objects on this server &
@@ -152,7 +154,9 @@ type SavedItem implements RemoteEntity @key(fields: "id") @key(fields: "url") {
   The title for user saved item. Set by the user and if not, set by the parser.
   For third party clients use-case only.
   """
-  title: String @deprecated(reason: "internal clients must use item.title") @tag(name: "alpha")
+  title: String
+    @deprecated(reason: "internal clients must use item.title")
+    @tag(name: "alpha")
   """
   Helper property to indicate if the SavedItem is favorited
   """
@@ -575,7 +579,7 @@ type User @key(fields: "id") {
   """
   Get a PocketSave(s) by its id(s)
   """
-  saveById(ids: [ID!]!): [SaveByIdResult!]!  @constraint(maxItems: 30)
+  saveById(ids: [ID!]!): [SaveByIdResult!]! @constraint(maxItems: 30)
 }
 """
 Union type for saveById - retrieving either PocketSaves or NotFound errors
@@ -599,7 +603,6 @@ union SaveMutationError = NotFound | SyncConflict # hypothetically others in the
 All types in this union should implement BaseError, for client fallback
 """
 union SavedItemMutationError = NotFound | SyncConflict # hypothetically others in the future
-
 enum PendingItemStatus {
   RESOLVED
   UNRESOLVED
@@ -618,7 +621,6 @@ type PendingItem @key(fields: "url") {
 type Item @key(fields: "givenUrl") {
   "key field to identify the Item entity in the Parser service"
   givenUrl: Url!
-  itemId: String! @shareable
 
   #Note more properties exist here but are defined in another service.
 
@@ -754,7 +756,7 @@ type Mutation {
   Maximum of 150 operations (adds/deletes) per request.
   """
   saveBatchUpdateTags(
-    input: [SaveUpdateTagsInput!]!  @constraint(minItems: 1, maxItems: 30),
+    input: [SaveUpdateTagsInput!]! @constraint(minItems: 1, maxItems: 30)
     timestamp: ISOString!
   ): SaveWriteMutationPayload! @tag(name: "alpha")
 
@@ -764,7 +766,7 @@ type Mutation {
   timestamp.
   """
   saveUpsert(
-    input: [SaveUpsertInput!]!  @constraint(minItems: 1, maxItems: 30),
+    input: [SaveUpsertInput!]! @constraint(minItems: 1, maxItems: 30)
     timestamp: ISOString!
   ): SaveWriteMutationPayload! @tag(name: "alpha")
 

--- a/src/test/graphql/queries/pocketSave-item.integration.ts
+++ b/src/test/graphql/queries/pocketSave-item.integration.ts
@@ -28,7 +28,6 @@ describe('PocketSave.Item', () => {
                   __typename
                 }
                 ... on Item {
-                  itemId
                   givenUrl
                   __typename
                 }
@@ -117,7 +116,6 @@ describe('PocketSave.Item', () => {
         variables,
       });
     const expected = {
-      itemId: '55',
       givenUrl: 'https://www.youtube.com/watch?v=nsNMP6_Q0Js',
       __typename: 'Item',
     };


### PR DESCRIPTION
## Goal
Removing `itemId` from the extended `Item` type as it does not get resolved and is not a key. Fixing integration tests.

Already have tested this change doesn't break anything by directly pushing up the client schema changes to prod

## References

Jira ticket:
* [https://getpocket.atlassian.net/browse/INFRA-1324](https://getpocket.atlassian.net/browse/INFRA-1324)

